### PR TITLE
Update versions to 0.3.0 for vim_rs and vim_macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.3.0] - 2025-12-28
+
+### Added
+
 - **`TaskTracker`**: High-level API for awaiting vSphere `Task` completion using PropertyCollector.
   - Efficient background monitoring with shared `ListView` and incremental updates.
   - Two APIs: `wait::<T>()` for convenient deserialization and `wait_any()` for zero-allocation path.

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2104,7 +2104,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vim_macros"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -2115,7 +2115,7 @@ dependencies = [
 
 [[package]]
 name = "vim_rs"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bytes",

--- a/examples/macro_examples/Cargo.toml
+++ b/examples/macro_examples/Cargo.toml
@@ -28,6 +28,6 @@ anyhow = "1.0"
 env_logger = "0.11"
 tokio = {  version = "1.44", features = ["macros"]}
 utils = { version = "0.1.0", path = "../utils" }
-vim_rs = { version = "0.2", path = "../../vim_rs" }
-vim_macros = { version = "0.2", path = "../../vim_macros" }
+vim_rs = { version = "0.3", path = "../../vim_rs" }
+vim_macros = { version = "0.3", path = "../../vim_macros" }
 log = "0.4.27"

--- a/examples/snippets/Cargo.toml
+++ b/examples/snippets/Cargo.toml
@@ -50,6 +50,6 @@ env_logger = "0.11"
 log = "0.4"
 utils = { version = "0.1", path = "../utils" }
 tokio = {  version = "1.44", features = ["macros"]}
-vim_macros = { version = "0.2", path = "../../vim_macros" }
-vim_rs = { version = "0.2", path = "../../vim_rs" }
+vim_macros = { version = "0.3", path = "../../vim_macros" }
+vim_rs = { version = "0.3", path = "../../vim_rs" }
 serde_json = "1.0"

--- a/examples/utils/Cargo.toml
+++ b/examples/utils/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2024"
 anyhow = "1.0"
 dotenvy = "0.15"
 log = "0.4"
-vim_rs = { version = "0.2", path = "../../vim_rs" }
+vim_rs = { version = "0.3", path = "../../vim_rs" }

--- a/examples/vtui/Cargo.toml
+++ b/examples/vtui/Cargo.toml
@@ -9,8 +9,8 @@ crossterm = {  version = "0.28", features = ["event-stream"]}
 futures = "0.3"
 tokio = {  version = "1.44", features = ["macros"]}
 ratatui = {  version = "0.29" , features = ["crossterm"]}
-vim_rs = { version = "0.2", path = "../../vim_rs" }
-vim_macros = { version = "0.2", path = "../../vim_macros" }
+vim_rs = { version = "0.3", path = "../../vim_rs" }
+vim_macros = { version = "0.3", path = "../../vim_macros" }
 chrono = "0.4"
 tui-tree-widget = "0.23"
 serde_json = "1.0"

--- a/mcp/data_processing/build_examples/src/lib.rs
+++ b/mcp/data_processing/build_examples/src/lib.rs
@@ -22,8 +22,8 @@ pub fn collect_examples(examples_dir: &Path) -> Result<Vec<CodeExample>> {
 
     // Dependency template for new projects
     let dependencies_template = r#"[dependencies]
-vim_rs = "0.2"
-vim_macros = "0.2"
+vim_rs = "0.3"
+vim_macros = "0.3"
 tokio = { version = "1.44", features = ["macros"] }
 anyhow = "1.0"
 log = "0.4"

--- a/mcp/server/guides/VIM_RS_STARTER_GUIDE.md
+++ b/mcp/server/guides/VIM_RS_STARTER_GUIDE.md
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
 **Dependencies needed:**
 ```toml
 [dependencies]
-vim_rs = "0.2"
+vim_rs = "0.3"
 anyhow = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.11"
@@ -188,7 +188,7 @@ async fn main() -> Result<()> {
 
 **Additional dependency:**
 ```toml
-vim_macros = "0.2"
+vim_macros = "0.3"
 ```
 
 **Key Points:**
@@ -1042,8 +1042,8 @@ async fn main() -> Result<()> {
 **Cargo.toml dependencies:**
 ```toml
 [dependencies]
-vim_rs = "0.2"
-vim_macros = "0.2"
+vim_rs = "0.3"
+vim_macros = "0.3"
 anyhow = "1.0"
 tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.11"

--- a/vim_macros/Cargo.lock
+++ b/vim_macros/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "vim_macros"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "phf",
  "proc-macro2",

--- a/vim_macros/Cargo.toml
+++ b/vim_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vim_macros"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 authors = ["Kiril Karaatanasov <karaatanasov@gmail.com>"]
 license = "Apache-2.0"

--- a/vim_rs/Cargo.lock
+++ b/vim_rs/Cargo.lock
@@ -1498,7 +1498,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vim_macros"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "vim_rs"
-version = "0.2.5"
+version = "0.3.0"
 dependencies = [
  "base64",
  "bytes",

--- a/vim_rs/Cargo.toml
+++ b/vim_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vim_rs"
-version = "0.2.5"
+version = "0.3.0"
 edition = "2021"
 authors = ["Kiril Karaatanasov <karaatanasov@gmail.com>"]
 license = "Apache-2.0"
@@ -27,7 +27,7 @@ strum = "0.27"
 strum_macros = "0.27"
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "sync"] }
-vim_macros = { version = "0.2", path = "../vim_macros" }
+vim_macros = { version = "0.3", path = "../vim_macros" }
 
 [build-dependencies]
 rustc_version = "0.4"


### PR DESCRIPTION
- Bump version numbers for `vim_rs` and `vim_macros` to 0.3.0 in various Cargo.toml and Cargo.lock files.
- Update CHANGELOG.md to reflect the new versioning.
- Ensure all examples and documentation reference the updated versions for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prepares the 0.3.0 release and aligns examples/docs with new versions.
> 
> - Adds `0.3.0` entry to `CHANGELOG.md` highlighting `TaskTracker`, and BREAKING changes (managed-object stubs use `VimClient` trait, `ObjectCacheListener` returns `CacheAction`, removal of `SharedRefCacheProxy`)
> - Bumps `vim_rs`/`vim_macros` to `0.3.0` in `vim_rs/` and `vim_macros/` crates and all examples (`macro_examples`, `snippets`, `utils`, `vtui`), plus lockfiles
> - Updates guides and MCP example builder templates to reference `vim_rs = "0.3"` and `vim_macros = "0.3"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b79ba8f2485bdc560c70581356412adcdf41b344. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->