### PR TITLE
v0.4.3 - wire logging

### DIFF
--- a/.github/workflows/vim-rs-tests.yml
+++ b/.github/workflows/vim-rs-tests.yml
@@ -1,0 +1,47 @@
+name: vim_rs tests
+
+on:
+  pull_request:
+    paths:
+      - "vim_rs/**"
+      - "vim_macros/**"
+      - ".github/workflows/vim-rs-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "vim_rs/**"
+      - "vim_macros/**"
+      - ".github/workflows/vim-rs-tests.yml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: cargo test (vim_rs, ${{ matrix.label }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: default
+            features: ""
+          - label: xml
+            features: "--features xml"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            vim_rs/target
+          key: vim-rs-test-${{ runner.os }}-${{ matrix.label }}-${{ hashFiles('vim_rs/Cargo.lock', 'vim_macros/Cargo.lock') }}
+
+      - name: Run tests
+        working-directory: vim_rs
+        run: cargo test --locked ${{ matrix.features }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ mcp/data/model_cache/
 **/logs/*.log
 logs/
 **/.DS_Store
+CLAUDE.md
+docs/**
+.cursor/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Wire logging:** `ClientBuilder::wire_logging` and `WireLoggingMode` for opt-in transport diagnostics on dedicated log targets (`vim_rs::wire::json`, `vim_rs::wire::soap`). Defaults to **`Off`**; no behavior change unless you enable it.
+  - **`WireLoggingMode::Summary`** — request/response metadata (sizes, paths, status, duration) at [`log::Level::Debug`].
+  - **`WireLoggingMode::Detailed`** — may include full request/response bodies at [`log::Level::Trace`] where allowed.
+  - **`SessionManager`** traffic (login, logout, session APIs) never logs bodies in detailed mode; logs stay summary-style with `body_logging=denylisted` / `mode=summary` as applicable.
+  - Import: `use vim_rs::WireLoggingMode;` (also available as `vim_rs::core::WireLoggingMode`).
+  - Typical filters: `RUST_LOG=vim_rs::wire::json=debug`, `vim_rs::wire::soap=debug`; use `=trace` on a target only when you need detailed bodies.
+
 ### Changed
 
 - **BREAKING:** `RootObjects` and `VsanObjectCatalog` now hold `VimClientHandle` (`Arc<dyn VimClient>`) instead of `Arc<Client>`. `RootObjects::new` / `VsanObjectCatalog::new` still accept `Arc<Client>` via coercion to the trait object. `RootObjects::client()` and `VsanObjectCatalog::client()` now return `VimClientHandle`; code that required `Arc<Client>` from those accessors must keep the concrete handle separately or adjust types.
 - `CacheManager::new` and `new_with_property_collector` use `Arc<dyn VimClient>` in their signatures (equivalent to the existing `VimClientHandle` alias).
 - `ObjectRetriever::new` uses `Arc<dyn VimClient>`
+- **Wire logging:** When wire logging is not [`WireLoggingMode::Off`], legacy transport-oriented `trace!` lines that dump request/response payloads are **not** emitted for the same paths (dedicated `vim_rs::wire::*` logs are authoritative). Other library `debug!` / `trace!` diagnostics are unchanged.
 
 ## [0.4.2] - 2026-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-04-10
+
 ### Added
 
 - **Wire logging:** `ClientBuilder::wire_logging` and `WireLoggingMode` for opt-in transport diagnostics on dedicated log targets (`vim_rs::wire::json`, `vim_rs::wire::soap`). Defaults to **`Off`**; no behavior change unless you enable it.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ The `client` above is an `Arc` around the actual client object. Use `.clone()` t
 
 If the above goes well, you have a connection to the vCenter server with an initialized session and retrieved service content.
 
+### Wire logging (transport diagnostics)
+
+For troubleshooting HTTP/SOAP request and response traffic, enable **wire logging** on the builder. It is **off by default** and uses dedicated log targets so you can filter transport lines separately from the rest of your application.
+
+```rust
+use vim_rs::core::ClientBuilder;
+use vim_rs::WireLoggingMode;
+
+let client = ClientBuilder::new("vcenter.example.com")
+    .basic_authn("administrator@vsphere.local", "password")
+    .app_details(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+    .wire_logging(WireLoggingMode::Summary)
+    .build()
+    .await?;
+```
+
+- **`WireLoggingMode::Off`** — no dedicated wire lines (default).
+- **`WireLoggingMode::Summary`** — metadata only (paths, sizes, HTTP status, duration) at `log::Level::Debug`. Use this first when diagnosing failures.
+- **`WireLoggingMode::Detailed`** — may include full bodies at `log::Level::Trace` for non-session traffic. **`SessionManager`** calls (login, logout, session APIs) never log bodies; they stay summary-only by design.
+
+Wire records use targets **`vim_rs::wire::json`** (VI JSON) and **`vim_rs::wire::soap`** (SOAP/XML). Prefer **target-scoped** filters instead of enabling global `trace` for the whole crate, for example:
+
+- `RUST_LOG=vim_rs::wire::json=debug`
+- `RUST_LOG=vim_rs::wire::soap=debug`
+- `RUST_LOG=vim_rs::wire::json=trace` (detailed JSON bodies, where allowed)
+
+Detailed wire logs can be large; use them for short-lived troubleshooting only.
+
 ## Optional XML transport
 
 The default transport is VI JSON and behaves like `0.4.0`. XML support is an **optional, experimental**
@@ -104,7 +132,7 @@ Important caveats:
 
 - XML transport currently works only for the core VIM APIs.
 - Other APIs such as VSAN, SPBM/PBM, SMS, VSLM, and EAM currently return errors over XML.
-- XML support is experimental. If a call fails, enable `trace` logging for `vim_rs` and capture the failing request/response packets.
+- XML support is experimental. If a call fails, use **wire logging** (`.wire_logging(WireLoggingMode::Summary)` or `Detailed`) and filter `vim_rs::wire::soap` / `vim_rs::wire::json` (see *Wire logging* above). For other library diagnostics, you can still raise the log level for `vim_rs` modules as needed.
 - Enabling the `xml` feature increases release binary size by about 500 KB and increases debug build times by about 30-40%.
 - Disabling the `xml` feature restores `0.4.0` transport behavior, build times, and executable size characteristics.
 

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2690,7 +2690,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vim_macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "phf 0.11.3",
  "proc-macro2",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "vim_rs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64",
  "bytes",

--- a/examples/snippets/Cargo.toml
+++ b/examples/snippets/Cargo.toml
@@ -80,6 +80,6 @@ chrono = "0.4"
 env_logger = "0.11"
 log = "0.4"
 tokio = { version = "1.44", features = ["macros"] }
-vim_rs = { version = "0.4.2", path = "../../vim_rs", features = ["defaults", "xml"] }
+vim_rs = { version = "0.4.3", path = "../../vim_rs", features = ["defaults", "xml"] }
 miniserde = "0.1"
 dotenvy = "0.15"

--- a/examples/vtui/Cargo.toml
+++ b/examples/vtui/Cargo.toml
@@ -9,7 +9,7 @@ crossterm = {  version = "0.29", features = ["event-stream"]}
 futures = "0.3"
 tokio = {  version = "1.44", features = ["macros"]}
 ratatui = {  version = "0.30" , features = ["crossterm"]}
-vim_rs = { version = "0.4.2", features = ["xml"], path = "../../vim_rs" }
+vim_rs = { version = "0.4.3", features = ["xml"], path = "../../vim_rs" }
 chrono = "0.4"
 tui-tree-widget = "0.24"
 miniserde = "0.1"

--- a/mcp/server/guides/VIM_RS_STARTER_GUIDE.md
+++ b/mcp/server/guides/VIM_RS_STARTER_GUIDE.md
@@ -44,6 +44,8 @@ pub async fn connect(app_name: &str, app_version: &str) -> Result<Arc<Client>> {
         .insecure(true)
         .basic_authn(username.as_str(), pwd.as_str())
         .app_details(app_name, app_version)
+        // Optional: `.wire_logging(vim_rs::WireLoggingMode::Summary)` for transport diagnostics
+        // on targets `vim_rs::wire::json` / `vim_rs::wire::soap` (default is `Off`).
         .build()
         .await?;
 
@@ -70,6 +72,7 @@ async fn main() -> Result<()> {
 - Client is thread-safe (`Arc<Client>`)
 - Managed-object stubs store an `Arc<dyn VimClient>` internally; `Client` implements `VimClient`.
 - Default transport is JSON. If you do nothing, behavior stays on the normal vCenter JSON path.
+- **Wire logging** (`ClientBuilder::wire_logging`) is optional and **defaults to `Off`**. When enabled, use `WireLoggingMode::Summary` first; switch to `Detailed` only if you need full bodies. Logs go to `vim_rs::wire::json` / `vim_rs::wire::soap` at `Debug` (summary) and `Trace` (detailed bodies where allowed). **`SessionManager`** traffic never logs bodies (login/session data stays summary-only). Filter by target (e.g. `RUST_LOG=vim_rs::wire::json=debug`) instead of turning on global `trace` for all of `vim_rs`.
 
 **Dependencies needed:**
 ```toml
@@ -80,6 +83,15 @@ tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.11"
 log = "0.4"
 ```
+
+### Step 1.0: Wire logging (ONLY FOR TRANSPORT DEBUGGING)
+
+Use this when you need to see what the client sends and receives on the wire. It does **not** replace normal application logging.
+
+1. Import `use vim_rs::WireLoggingMode;`.
+2. Start with **`WireLoggingMode::Summary`** on the builder. Summary lines use `log::Level::Debug` on targets `vim_rs::wire::json` and/or `vim_rs::wire::soap`.
+3. If the failure is still unclear, use **`WireLoggingMode::Detailed`**. Full bodies are emitted at `log::Level::Trace` only where allowed; **`SessionManager`** calls remain summary-only (do not expect login/session payload bodies).
+4. Configure your logger by **target**, e.g. `RUST_LOG=vim_rs::wire::json=debug` or `vim_rs::wire::json=trace` — avoid blanket `vim_rs=trace` unless you also want every other diagnostic.
 
 ### Step 1.1: XML Transport (ONLY WHEN YOU ACTUALLY NEED IT)
 
@@ -115,6 +127,7 @@ pub async fn connect_auto(app_name: &str, app_version: &str) -> Result<Arc<Clien
         .basic_authn(username.as_str(), pwd.as_str())
         .app_details(app_name, app_version)
         .transport(TransportMode::Auto)
+        // Optional: `.wire_logging(vim_rs::WireLoggingMode::Summary)` — see Step 1.0
         .build()
         .await?;
 
@@ -131,7 +144,7 @@ Use `TransportMode::Soap` when you know you are talking directly to ESXi or you 
 **Critical XML caveats:**
 - XML currently works only for the core VIM APIs.
 - VSAN, SPBM/PBM, SMS, VSLM, EAM, and other non-VIM APIs will return errors over XML transport.
-- XML support is experimental. If it fails, turn on `trace` logging for `vim_rs` and capture the failing request/response packets.
+- XML support is experimental. If it fails, enable **wire logging** (`ClientBuilder::wire_logging` with `WireLoggingMode::Summary` or `Detailed`) and filter `vim_rs::wire::soap` / `vim_rs::wire::json` (see Step 1.0). Do not rely on generic `trace` for the whole crate as the primary transport capture mechanism.
 - Enabling `xml` increases release binary size by about 500 KB and increases debug build times by about 30-40%.
 - If the `xml` feature is not enabled, vim_rs returns to `0.4.0` transport, size, and build-time characteristics.
 

--- a/vim_macros/Cargo.lock
+++ b/vim_macros/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "vim_macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "phf",
  "proc-macro2",

--- a/vim_macros/Cargo.toml
+++ b/vim_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vim_macros"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Kiril Karaatanasov <karaatanasov@gmail.com>"]
 license = "Apache-2.0"

--- a/vim_rs/Cargo.lock
+++ b/vim_rs/Cargo.lock
@@ -1889,7 +1889,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vim_macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "phf 0.11.3",
  "proc-macro2",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "vim_rs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64",
  "bytes",

--- a/vim_rs/Cargo.toml
+++ b/vim_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vim_rs"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Kiril Karaatanasov <karaatanasov@gmail.com>"]
 license = "Apache-2.0"
@@ -28,7 +28,7 @@ quick-xml = { version = "0.39", optional = true }
 reqwest = { version = "0.12" }
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "sync"] }
-vim_macros = { version = "0.4.2", path = "../vim_macros" }
+vim_macros = { version = "0.4.3", path = "../vim_macros" }
 phf = "0.13"
 
 [build-dependencies]

--- a/vim_rs/src/core/client.rs
+++ b/vim_rs/src/core/client.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use tokio::sync::RwLock;
 use super::super::types::structs;
+use super::wire_log;
 use log::{warn, debug, trace};
 
 use bytes::Bytes;
@@ -226,6 +228,40 @@ pub enum TransportMode {
     Auto,
 }
 
+/// Explicit wire capture mode for VI JSON / SOAP traffic.
+///
+/// Emits on log targets `vim_rs::wire::json` and `vim_rs::wire::soap`. Summary metadata uses
+/// [`log::Level::Debug`]; full request/response bodies use [`log::Level::Trace`] when
+/// [`WireLoggingMode::Detailed`] applies and the managed object type is not denylisted.
+///
+/// **Denylist:** traffic for managed object type `SessionManager` (login, logout, session APIs)
+/// never logs bodies, even in detailed mode; emitted lines use summary-style fields and may include
+/// `body_logging=denylisted`.
+///
+/// When any wire mode other than [`WireLoggingMode::Off`] is active, legacy transport `trace!` lines
+/// that duplicate full request/response dumps are suppressed for those paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WireLoggingMode {
+    /// Default: no dedicated wire log lines; existing library `debug!` / `trace!` behavior unchanged.
+    #[default]
+    Off,
+    /// Request/response metadata only (sizes, paths, status, duration) at [`log::Level::Debug`].
+    Summary,
+    /// Adds full bodies at [`log::Level::Trace`] where allowed (`SessionManager` remains summary-only).
+    Detailed,
+}
+
+impl WireLoggingMode {
+    /// `true` when dedicated wire logs may be emitted (Summary or Detailed).
+    pub const fn is_enabled(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+    /// `true` when full bodies may be logged at [`log::Level::Trace`] (subject to denylist).
+    pub const fn is_detailed(self) -> bool {
+        matches!(self, Self::Detailed)
+    }
+}
+
 pub struct ClientBuilder {
     server_address: String,
     compatible_api_releases: Option<Vec<String>>,
@@ -238,6 +274,7 @@ pub struct ClientBuilder {
     password: Option<String>,
     locale: Option<String>,
     transport_mode: TransportMode,
+    wire_logging: WireLoggingMode,
 }
 
 impl ClientBuilder {
@@ -257,7 +294,19 @@ impl ClientBuilder {
             password: None,
             locale: None,
             transport_mode: TransportMode::default(),
+            wire_logging: WireLoggingMode::default(),
         }
+    }
+
+    /// Opt-in transport logging on dedicated log targets (`vim_rs::wire::json`, `vim_rs::wire::soap`).
+    ///
+    /// Defaults to [`WireLoggingMode::Off`]. Summary records use [`log::Level::Debug`]; full bodies in
+    /// [`WireLoggingMode::Detailed`] use [`log::Level::Trace`] except for `SessionManager` traffic,
+    /// which stays summary-only. Prefer filtering by target (e.g. `RUST_LOG=vim_rs::wire::json=debug`)
+    /// instead of raising global trace for the entire crate.
+    pub fn wire_logging(mut self, mode: WireLoggingMode) -> Self {
+        self.wire_logging = mode;
+        self
     }
 
     /// Set the transport mode. Requires the `xml` feature for `Soap` and `Auto`.
@@ -354,6 +403,7 @@ impl ClientBuilder {
     }
 
     async fn build_json(self) -> Result<Arc<Client>> {
+        let wire_logging = self.wire_logging;
         let http_client = match self.http_client {
             Some(client) => client,
             None => {
@@ -380,13 +430,57 @@ impl ClientBuilder {
                 };
                 let path = format!("https://{}/api/vcenter/system?action=hello", self.server_address);
                 let json_body = miniserde::json::to_string(&spec);
+                let started = Instant::now();
+                if wire_logging.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(wire_logging, "");
+                    let msg = format!(
+                        "wire=json mode={} phase=request kind=negotiate path={} body_bytes={}",
+                        mode_l,
+                        path,
+                        json_body.len()
+                    );
+                    wire_log::log_json_line(wire_logging, "", false, &msg);
+                }
                 let req = http_client.post(&path)
                     .header("Content-Type", "application/json")
                     .header("User-Agent", &user_agent)
                     .body(json_body);
-                let res = req.send().await?;
-                let res = res.error_for_status()?;
-                let body = res.text().await?;
+                let res = match req.send().await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        wire_log::log_json_negotiate_transport_failure(
+                            wire_logging,
+                            &path,
+                            started.elapsed(),
+                            &e,
+                        );
+                        return Err(Error::ReqwestError(e));
+                    }
+                };
+                let status = res.status();
+                // Same classification as `Response::error_for_status()` (4xx/5xx → reqwest::Error).
+                let http_err = res.error_for_status_ref().err();
+                let body = res.text().await.map_err(Error::ReqwestError)?;
+                let elapsed = started.elapsed();
+                if wire_logging.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(wire_logging, "");
+                    let detailed = wire_logging.is_detailed();
+                    let mut msg = format!(
+                        "wire=json mode={} phase=response kind=negotiate path={} status={} body_bytes={} duration_ms={}",
+                        mode_l,
+                        path,
+                        status.as_u16(),
+                        body.len(),
+                        elapsed.as_millis()
+                    );
+                    if detailed {
+                        msg.push_str(&format!(" body={}", body));
+                    }
+                    wire_log::log_json_line(wire_logging, "", detailed, &msg);
+                }
+                if let Some(e) = http_err {
+                    return Err(Error::ReqwestError(e));
+                }
                 let result: HelloResult = miniserde::json::from_str(&body)
                     .map_err(|_| Error::ParseError("Failed to parse HelloResult".to_string()))?;
                 let api_release = result.api_release;
@@ -409,6 +503,7 @@ impl ClientBuilder {
             base_url: base_url.clone(),
             user_agent: user_agent.clone(),
             service_content: None,
+            wire_logging: wire_logging,
         });
 
         let service_instance = mo::ServiceInstance::new(bootstrap.clone(), SERVICE_INSTANCE_MOID);
@@ -424,6 +519,7 @@ impl ClientBuilder {
             base_url: base_url.clone(),
             user_agent: user_agent.clone(),
             service_content: Some(content),
+            wire_logging: wire_logging,
         });
 
         if let (Some(ref sm_id), Some(ref user_name), Some(ref password)) = (sm_id, self.user_name, self.password) {
@@ -454,7 +550,11 @@ impl ClientBuilder {
             None => API_RELEASE.to_string(),
         };
         let mut soap = crate::xml::client::SoapClient::new(
-            http_client, &self.server_address, &api_release, &ua,
+            http_client,
+            &self.server_address,
+            &api_release,
+            &ua,
+            self.wire_logging,
         );
         soap.bootstrap().await?;
 
@@ -471,6 +571,7 @@ impl ClientBuilder {
 
     #[cfg(feature = "xml")]
     async fn build_auto_facade(self) -> Result<Arc<Client>> {
+        let wl = self.wire_logging;
         let ua = user_agent(self.app_name.as_deref(), self.app_version.as_deref());
         let http_client_for_probe = {
             let mut builder = reqwest::ClientBuilder::new();
@@ -486,6 +587,17 @@ impl ClientBuilder {
         let hello_url = format!("https://{}/api/vcenter/system?action=hello", self.server_address);
         let spec = HelloSpec { api_releases: &releases };
         let json_body = miniserde::json::to_string(&spec);
+        let started = Instant::now();
+        if wl.is_enabled() {
+            let mode_l = wire_log::wire_mode_label(wl, "");
+            let msg = format!(
+                "wire=json mode={} phase=request kind=probe path={} body_bytes={}",
+                mode_l,
+                hello_url,
+                json_body.len()
+            );
+            wire_log::log_json_line(wl, "", false, &msg);
+        }
 
         let hello_ok = match http_client_for_probe
             .post(&hello_url)
@@ -495,13 +607,48 @@ impl ClientBuilder {
             .send()
             .await
         {
-            Ok(res) if res.status().is_success() => {
+            Ok(res) => {
+                let status = res.status();
                 let body = res.text().await.unwrap_or_default();
-                miniserde::json::from_str::<HelloResult>(&body)
-                    .ok()
-                    .filter(|r| !r.api_release.is_empty())
+                let elapsed = started.elapsed();
+                if wl.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(wl, "");
+                    let detailed = wl.is_detailed();
+                    let mut msg = format!(
+                        "wire=json mode={} phase=response kind=probe path={} status={} body_bytes={} duration_ms={}",
+                        mode_l,
+                        hello_url,
+                        status.as_u16(),
+                        body.len(),
+                        elapsed.as_millis()
+                    );
+                    if detailed {
+                        msg.push_str(&format!(" body={}", body));
+                    }
+                    wire_log::log_json_line(wl, "", detailed, &msg);
+                }
+                if status.is_success() {
+                    miniserde::json::from_str::<HelloResult>(&body)
+                        .ok()
+                        .filter(|r| !r.api_release.is_empty())
+                } else {
+                    None
+                }
             }
-            _ => None,
+            Err(e) => {
+                if wl.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(wl, "");
+                    let msg = format!(
+                        "wire=json mode={} phase=response kind=probe path={} error=transport body_bytes=0 duration_ms={} detail={}",
+                        mode_l,
+                        hello_url,
+                        started.elapsed().as_millis(),
+                        e
+                    );
+                    wire_log::log_json_line(wl, "", false, &msg);
+                }
+                None
+            }
         };
 
         if hello_ok.is_some() {
@@ -618,6 +765,23 @@ impl VimClient for Client {
     }
 }
 
+pub(crate) struct JsonWireCtx<'a> {
+    pub svc: &'a str,
+    pub mo_type: &'a str,
+    pub mo_id: &'a str,
+    pub name: &'a str,
+    pub path: &'a str,
+    pub is_property_get: bool,
+}
+
+fn json_method_path(svc: &str, mo_type: &str, mo_id: &str, method_name: &str) -> String {
+    if svc.is_empty() {
+        format!("/{mo_type}/{mo_id}/{method_name}")
+    } else {
+        format!("/{svc}/{mo_type}/{mo_id}/{method_name}")
+    }
+}
+
 pub(crate) struct JsonClient {
     http_client: reqwest::Client,
     session_key: Arc<RwLock<Option<String>>>,
@@ -625,6 +789,7 @@ pub(crate) struct JsonClient {
     base_url: String,
     user_agent: String,
     service_content: Option<ServiceContent>,
+    wire_logging: WireLoggingMode,
 }
 
 /// VI JSON API implementation (Hello + `/sdk/vim25/{release}`). Crate-private; users hold [`Client`].
@@ -662,7 +827,7 @@ impl JsonClient {
         method_name: &str,
         params: Option<&(dyn miniserde::Serialize + Send + Sync)>,
     ) -> reqwest::RequestBuilder {
-        let path =  if svc.is_empty() {
+        let path = if svc.is_empty() {
             format!("/{mo_type}/{mo_id}/{method_name}")
         } else {
             format!("/{svc}/{mo_type}/{mo_id}/{method_name}")
@@ -671,7 +836,35 @@ impl JsonClient {
             Some(payload) => {
                 debug!("POST request: {}", path);
                 let json_body = miniserde::json::to_string(payload);
-                if log::log_enabled!(log::Level::Trace) {
+                if self.wire_logging.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+                    let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+                    let deny_s = deny.unwrap_or("");
+                    let deny_sep = if deny_s.is_empty() { "" } else { " " };
+                    let mut msg = format!(
+                        "wire=json mode={} phase=request svc=\"{}\" mo={} id={} method={} path={} body_bytes={}{}{}",
+                        mode_l,
+                        svc,
+                        mo_type,
+                        mo_id,
+                        method_name,
+                        path,
+                        json_body.len(),
+                        deny_sep,
+                        deny_s
+                    );
+                    if wire_log::bodies_allowed(self.wire_logging, mo_type) {
+                        msg.push_str(&format!(" body={}", json_body));
+                    }
+                    wire_log::log_json_line(
+                        self.wire_logging,
+                        mo_type,
+                        wire_log::bodies_allowed(self.wire_logging, mo_type),
+                        &msg,
+                    );
+                } else if log::log_enabled!(log::Level::Trace)
+                    && !wire_log::suppress_legacy_transport_trace(self.wire_logging)
+                {
                     trace!("POST payload: {}", json_body);
                 }
                 let url = format!("{}{}", self.base_url, path);
@@ -680,16 +873,85 @@ impl JsonClient {
                     .header("Content-Type", "application/json")
                     .body(json_body)
             }
-            None => self.post_bare(&path),
+            None => {
+                if self.wire_logging.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+                    let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+                    let deny_s = deny.unwrap_or("");
+                    let deny_sep = if deny_s.is_empty() { "" } else { " " };
+                    let msg = format!(
+                        "wire=json mode={} phase=request svc=\"{}\" mo={} id={} method={} path={} body_bytes=0{}{}",
+                        mode_l,
+                        svc,
+                        mo_type,
+                        mo_id,
+                        method_name,
+                        path,
+                        deny_sep,
+                        deny_s
+                    );
+                    wire_log::log_json_line(self.wire_logging, mo_type, false, &msg);
+                }
+                self.post_bare(&path)
+            }
         }
     }
 
     /// Execute a request that does not return a response body
-    pub(crate) async fn execute_void(&self, mut req: reqwest::RequestBuilder) -> Result<()>
-    {
+    pub(crate) async fn execute_void(
+        &self,
+        mut req: reqwest::RequestBuilder,
+        ctx: Option<JsonWireCtx<'_>>,
+        started: Instant,
+    ) -> Result<()> {
         req = self.prepare(req).await;
-        let res = req.send().await?;
-        let _ = self.process_response(res).await?;
+        let res = match req.send().await {
+            Ok(r) => r,
+            Err(e) => {
+                if self.wire_logging.is_enabled() {
+                    if let Some(c) = ctx.as_ref() {
+                        wire_log::log_json_transport_failure(
+                            self.wire_logging,
+                            c.svc,
+                            c.mo_type,
+                            c.mo_id,
+                            c.name,
+                            c.path,
+                            c.is_property_get,
+                            started.elapsed(),
+                            &e,
+                        );
+                    }
+                }
+                return Err(Error::ReqwestError(e));
+            }
+        };
+        let res = self
+            .process_response(res, Some(started), ctx.as_ref())
+            .await?;
+        if self.wire_logging.is_enabled() {
+            if let Some(c) = ctx.as_ref() {
+                let mode_l = wire_log::wire_mode_label(self.wire_logging, c.mo_type);
+                let deny = wire_log::body_logging_note(self.wire_logging, c.mo_type);
+                let deny_s = deny.unwrap_or("");
+                let deny_sep = if deny_s.is_empty() { "" } else { " " };
+                let name_field = format!("method={}", c.name);
+                let msg = format!(
+                    "wire=json mode={} phase=response svc=\"{}\" mo={} id={} {} path={} status={} body_bytes=0 duration_ms={}{}{}",
+                    mode_l,
+                    c.svc,
+                    c.mo_type,
+                    c.mo_id,
+                    name_field,
+                    c.path,
+                    res.status().as_u16(),
+                    started.elapsed().as_millis(),
+                    deny_sep,
+                    deny_s
+                );
+                wire_log::log_json_line(self.wire_logging, c.mo_type, false, &msg);
+            }
+        }
         Ok(())
     }
 
@@ -704,7 +966,12 @@ impl JsonClient {
     }
 
     /// Handle authn header update and error unmarsalling
-    async fn process_response(&self, res: reqwest::Response) -> Result<reqwest::Response> {
+    async fn process_response(
+        &self,
+        res: reqwest::Response,
+        started: Option<Instant>,
+        ctx: Option<&JsonWireCtx<'_>>,
+    ) -> Result<reqwest::Response> {
         if res.status().is_success() && res.headers().contains_key(AUTHN_HEADER) {
             let session_key = res.headers().get(AUTHN_HEADER).unwrap().to_str().map_err(|_| Error::MissingOrInvalidSessionKey)?.to_string();
             let mut key_holder = self.session_key.write().await;
@@ -712,7 +979,24 @@ impl JsonClient {
         }
         if !res.status().is_success() {
             warn!("HTTP error: {}", res.status());
+            let status = res.status();
             let body = res.text().await?;
+            if let (Some(start), Some(c)) = (started, ctx) {
+                if self.wire_logging.is_enabled() {
+                    wire_log::log_json_http_error(
+                        self.wire_logging,
+                        c.svc,
+                        c.mo_type,
+                        c.mo_id,
+                        c.name,
+                        c.path,
+                        c.is_property_get,
+                        status,
+                        &body,
+                        start.elapsed(),
+                    );
+                }
+            }
             let fault: structs::MethodFault = miniserde::json::from_str(&body)
                 .map_err(|_| Error::ParseError(format!("Failed to parse MethodFault from error response: {}", &body[..body.len().min(200)])))?;
             return Err(Error::MethodFault(fault));
@@ -743,14 +1027,79 @@ impl VimClient for JsonClient {
         params: Option<&'a (dyn miniserde::Serialize + Send + Sync)>,
     ) -> BoxFuture<'a, Result<Bytes>> {
         Box::pin(async move {
+            let path_str = json_method_path(svc, mo_type, mo_id, method_name);
+            let ctx = JsonWireCtx {
+                svc,
+                mo_type,
+                mo_id,
+                name: method_name,
+                path: path_str.as_str(),
+                is_property_get: false,
+            };
+            let started = Instant::now();
             let req = self.build_post_request(svc, mo_type, mo_id, method_name, params);
             let req = self.prepare(req).await;
-            let res = req.send().await?;
-            let res = self.process_response(res).await?;
+            let res = match req.send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    wire_log::log_json_transport_failure(
+                        self.wire_logging,
+                        svc,
+                        mo_type,
+                        mo_id,
+                        method_name,
+                        path_str.as_str(),
+                        false,
+                        started.elapsed(),
+                        &e,
+                    );
+                    return Err(Error::ReqwestError(e));
+                }
+            };
+            let res = self
+                .process_response(res, Some(started), Some(&ctx))
+                .await?;
+            let http_status = res.status();
             let bytes = res.bytes().await?;
-            if log::log_enabled!(log::Level::Trace) {
+            if self.wire_logging.is_enabled() {
+                let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+                let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+                let deny_s = deny.unwrap_or("");
+                let deny_sep = if deny_s.is_empty() { "" } else { " " };
+                let body_lossy = wire_log::sanitize_utf8(&bytes);
+                let mut msg = format!(
+                    "wire=json mode={} phase=response svc=\"{}\" mo={} id={} method={} path={} status={} body_bytes={} duration_ms={}{}{}",
+                    mode_l,
+                    svc,
+                    mo_type,
+                    mo_id,
+                    method_name,
+                    path_str,
+                    http_status.as_u16(),
+                    bytes.len(),
+                    started.elapsed().as_millis(),
+                    deny_sep,
+                    deny_s
+                );
+                if wire_log::bodies_allowed(self.wire_logging, mo_type) {
+                    msg.push_str(&format!(" body={}", body_lossy));
+                }
+                wire_log::log_json_line(
+                    self.wire_logging,
+                    mo_type,
+                    wire_log::bodies_allowed(self.wire_logging, mo_type),
+                    &msg,
+                );
+            } else if log::log_enabled!(log::Level::Trace)
+                && !wire_log::suppress_legacy_transport_trace(self.wire_logging)
+            {
                 let body = String::from_utf8_lossy(&bytes);
-                trace!("JSON response from {}/{}: {}...", mo_type, method_name, &body[..body.len().min(2000)]);
+                trace!(
+                    "JSON response from {}/{}: {}...",
+                    mo_type,
+                    method_name,
+                    &body[..body.len().min(2000)]
+                );
             }
             Ok(bytes)
         })
@@ -765,16 +1114,86 @@ impl VimClient for JsonClient {
         params: Option<&'a (dyn miniserde::Serialize + Send + Sync)>,
     ) -> BoxFuture<'a, Result<Option<Bytes>>> {
         Box::pin(async move {
+            let path_str = json_method_path(svc, mo_type, mo_id, method_name);
+            let ctx = JsonWireCtx {
+                svc,
+                mo_type,
+                mo_id,
+                name: method_name,
+                path: path_str.as_str(),
+                is_property_get: false,
+            };
+            let started = Instant::now();
             let req = self.build_post_request(svc, mo_type, mo_id, method_name, params);
             let req = self.prepare(req).await;
-            let res = req.send().await?;
-            let res = self.process_response(res).await?;
+            let res = match req.send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    wire_log::log_json_transport_failure(
+                        self.wire_logging,
+                        svc,
+                        mo_type,
+                        mo_id,
+                        method_name,
+                        path_str.as_str(),
+                        false,
+                        started.elapsed(),
+                        &e,
+                    );
+                    return Err(Error::ReqwestError(e));
+                }
+            };
+            let res = self
+                .process_response(res, Some(started), Some(&ctx))
+                .await?;
+            let http_status = res.status();
             let bytes = res.bytes().await?;
-            if log::log_enabled!(log::Level::Trace) && !bytes.is_empty() {
+            if self.wire_logging.is_enabled() && !bytes.is_empty() {
+                let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+                let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+                let deny_s = deny.unwrap_or("");
+                let deny_sep = if deny_s.is_empty() { "" } else { " " };
+                let body_lossy = wire_log::sanitize_utf8(&bytes);
+                let mut msg = format!(
+                    "wire=json mode={} phase=response svc=\"{}\" mo={} id={} method={} path={} status={} body_bytes={} duration_ms={}{}{}",
+                    mode_l,
+                    svc,
+                    mo_type,
+                    mo_id,
+                    method_name,
+                    path_str,
+                    http_status.as_u16(),
+                    bytes.len(),
+                    started.elapsed().as_millis(),
+                    deny_sep,
+                    deny_s
+                );
+                if wire_log::bodies_allowed(self.wire_logging, mo_type) {
+                    msg.push_str(&format!(" body={}", body_lossy));
+                }
+                wire_log::log_json_line(
+                    self.wire_logging,
+                    mo_type,
+                    wire_log::bodies_allowed(self.wire_logging, mo_type),
+                    &msg,
+                );
+            } else if log::log_enabled!(log::Level::Trace)
+                && !bytes.is_empty()
+                && !wire_log::suppress_legacy_transport_trace(self.wire_logging)
+            {
                 let body = String::from_utf8_lossy(&bytes);
-                trace!("JSON response from {}/{}: {}...", mo_type, method_name, &body[..body.len().min(2000)]);
+                trace!(
+                    "JSON response from {}/{}: {}...",
+                    mo_type,
+                    method_name,
+                    &body[..body.len().min(2000)]
+                );
             }
-            if bytes.is_empty() { Ok(None) } else { Ok(Some(bytes)) }
+            if bytes.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(bytes))
+            }
         })
     }
 
@@ -787,8 +1206,18 @@ impl VimClient for JsonClient {
         params: Option<&'a (dyn miniserde::Serialize + Send + Sync)>,
     ) -> BoxFuture<'a, Result<()>> {
         Box::pin(async move {
+            let path_str = json_method_path(svc, mo_type, mo_id, method_name);
+            let ctx = JsonWireCtx {
+                svc,
+                mo_type,
+                mo_id,
+                name: method_name,
+                path: path_str.as_str(),
+                is_property_get: false,
+            };
+            let started = Instant::now();
             let req = self.build_post_request(svc, mo_type, mo_id, method_name, params);
-            JsonClient::execute_void(self, req).await
+            JsonClient::execute_void(self, req, Some(ctx), started).await
         })
     }
 
@@ -805,14 +1234,97 @@ impl VimClient for JsonClient {
             } else {
                 format!("/{svc}/{mo_type}/{mo_id}/{property}")
             };
+            let ctx = JsonWireCtx {
+                svc,
+                mo_type,
+                mo_id,
+                name: property,
+                path: path.as_str(),
+                is_property_get: true,
+            };
+            let started = Instant::now();
+            if self.wire_logging.is_enabled() {
+                let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+                let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+                let deny_s = deny.unwrap_or("");
+                let deny_sep = if deny_s.is_empty() { "" } else { " " };
+                let msg = format!(
+                    "wire=json mode={} phase=request svc=\"{}\" mo={} id={} property={} path={} body_bytes=0{}{}",
+                    mode_l,
+                    svc,
+                    mo_type,
+                    mo_id,
+                    property,
+                    path,
+                    deny_sep,
+                    deny_s
+                );
+                wire_log::log_json_line(self.wire_logging, mo_type, false, &msg);
+            }
             let req = self.get_request(&path);
             let req = self.prepare(req).await;
-            let res = req.send().await?;
-            let res = self.process_response(res).await?;
+            let res = match req.send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    wire_log::log_json_transport_failure(
+                        self.wire_logging,
+                        svc,
+                        mo_type,
+                        mo_id,
+                        property,
+                        path.as_str(),
+                        true,
+                        started.elapsed(),
+                        &e,
+                    );
+                    return Err(Error::ReqwestError(e));
+                }
+            };
+            let res = self
+                .process_response(res, Some(started), Some(&ctx))
+                .await?;
+            let http_status = res.status();
             let bytes = res.bytes().await?;
-            if log::log_enabled!(log::Level::Trace) && !bytes.is_empty() {
+            if self.wire_logging.is_enabled() && !bytes.is_empty() {
+                let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+                let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+                let deny_s = deny.unwrap_or("");
+                let deny_sep = if deny_s.is_empty() { "" } else { " " };
+                let body_lossy = wire_log::sanitize_utf8(&bytes);
+                let mut msg = format!(
+                    "wire=json mode={} phase=response svc=\"{}\" mo={} id={} property={} path={} status={} body_bytes={} duration_ms={}{}{}",
+                    mode_l,
+                    svc,
+                    mo_type,
+                    mo_id,
+                    property,
+                    path,
+                    http_status.as_u16(),
+                    bytes.len(),
+                    started.elapsed().as_millis(),
+                    deny_sep,
+                    deny_s
+                );
+                if wire_log::bodies_allowed(self.wire_logging, mo_type) {
+                    msg.push_str(&format!(" body={}", body_lossy));
+                }
+                wire_log::log_json_line(
+                    self.wire_logging,
+                    mo_type,
+                    wire_log::bodies_allowed(self.wire_logging, mo_type),
+                    &msg,
+                );
+            } else if log::log_enabled!(log::Level::Trace)
+                && !bytes.is_empty()
+                && !wire_log::suppress_legacy_transport_trace(self.wire_logging)
+            {
                 let body = String::from_utf8_lossy(&bytes);
-                trace!("JSON fetch_property_raw {}/{}: {}...", mo_type, property, &body[..body.len().min(2000)]);
+                trace!(
+                    "JSON fetch_property_raw {}/{}: {}...",
+                    mo_type,
+                    property,
+                    &body[..body.len().min(2000)]
+                );
             }
             if bytes.is_empty() {
                 Ok(None)
@@ -832,6 +1344,7 @@ impl Drop for JsonClient {
         let session_key = Arc::clone(&self.session_key);
         let http_client = &self.http_client.clone();
         let base_url = self.base_url.clone();
+        let wire_logging = self.wire_logging;
 
         let sm_id = self.service_content.as_ref().and_then(|content| content.session_manager.as_ref().map(|moid| moid.value.clone()));
         let sm_id = match sm_id {
@@ -858,26 +1371,65 @@ impl Drop for JsonClient {
                 let path = format!("{base_url}/SessionManager/{moId}/Logout",
                                     base_url = base_url,
                                     moId = sm_id);
+                if wire_logging.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(wire_logging, "SessionManager");
+                    let msg = format!(
+                        "wire=json mode={} phase=request kind=logout mo=SessionManager id={} method=Logout path={} body_bytes=0 body_logging=denylisted",
+                        mode_l,
+                        sm_id,
+                        path
+                    );
+                    wire_log::log_json_line(wire_logging, "SessionManager", false, &msg);
+                }
                 let req = http_client.post(&path)
                                         .header(AUTHN_HEADER, key);
+                let started = Instant::now();
                 match req.send().await {
                     Ok(resp) => {
                         let status = resp.status();
+                        let body = resp.text().await.unwrap_or_default();
+                        let dur = started.elapsed();
+                        if wire_logging.is_enabled() {
+                            let mode_l = wire_log::wire_mode_label(wire_logging, "SessionManager");
+                            let http_note = if status.is_success() {
+                                ""
+                            } else {
+                                " error=http_failure"
+                            };
+                            let msg = format!(
+                                "wire=json mode={} phase=response kind=logout mo=SessionManager id={} method=Logout status={} body_bytes={} duration_ms={} body_logging=denylisted{}",
+                                mode_l,
+                                sm_id,
+                                status.as_u16(),
+                                body.len(),
+                                dur.as_millis(),
+                                http_note
+                            );
+                            wire_log::log_json_line(wire_logging, "SessionManager", false, &msg);
+                        }
                         if status.is_success() {
                             debug!("Session logged out successfully");
                         } else {
-                            match resp.text().await {
-                                Ok(body) => {
-                                    match miniserde::json::from_str::<structs::MethodFault>(&body) {
-                                        Ok(fault) => warn!("Failed to logout session(HTTP code: {}). MethodFault: {:?}", status, fault),
-                                        Err(_) => warn!("Failed to logout session(HTTP code: {}). Cannot parse MethodFault: {}", status, &body[..body.len().min(200)]),
-                                    }
-                                },
-                                Err(e) => warn!("Failed to logout session(HTTP code: {}). Cannot read response: {}", status, e),
+                            match miniserde::json::from_str::<structs::MethodFault>(&body) {
+                                Ok(fault) => warn!("Failed to logout session(HTTP code: {}). MethodFault: {:?}", status, fault),
+                                Err(_) => warn!("Failed to logout session(HTTP code: {}). Cannot parse MethodFault: {}", status, &body[..body.len().min(200)]),
                             }
                         }
-                    },
-                    Err(e) => warn!("Failed to logout session. Cannot execute logout request: {}", e),
+                    }
+                    Err(e) => {
+                        if wire_logging.is_enabled() {
+                            let mode_l = wire_log::wire_mode_label(wire_logging, "SessionManager");
+                            let msg = format!(
+                                "wire=json mode={} phase=response kind=logout mo=SessionManager id={} method=Logout error=transport duration_ms={} body_logging=denylisted detail={}",
+                                mode_l,
+                                sm_id,
+                                started.elapsed().as_millis(),
+                                e
+                            );
+                            wire_log::log_json_line(wire_logging, "SessionManager", false, &msg);
+                        }
+                        warn!("Failed to logout session. Cannot execute logout request: {}", e);
+                    }
                 }
             });
         });
@@ -1014,5 +1566,590 @@ impl std::fmt::Debug for HelloResult {
         f.debug_struct("HelloResult")
             .field("api_release", &self.api_release)
             .finish()
+    }
+}
+
+/// Shared by wire-logging transport tests (`core` + `xml` client).
+#[cfg(test)]
+pub(crate) fn test_dead_port_http_client() -> reqwest::Client {
+    #[cfg(feature = "xml")]
+    {
+        return reqwest::Client::builder()
+            .cookie_store(true)
+            .connect_timeout(std::time::Duration::from_millis(500))
+            .timeout(std::time::Duration::from_secs(3))
+            .build()
+            .expect("reqwest test client");
+    }
+    #[cfg(not(feature = "xml"))]
+    {
+        reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_millis(500))
+            .timeout(std::time::Duration::from_secs(3))
+            .build()
+            .expect("reqwest test client")
+    }
+}
+
+/// Unbound TCP address used to force `send()` transport failures quickly.
+#[cfg(test)]
+pub(crate) const TEST_WIRE_DEAD_ADDR: &str = "127.0.0.1:65433";
+
+#[cfg(test)]
+pub(crate) fn test_minimal_service_content_for_tests() -> ServiceContent {
+    let json = r#"{
+        "_typeName": "ServiceContent",
+        "rootFolder": {"_typeName":"ManagedObjectReference","type":"Folder","value":"root-1"},
+        "propertyCollector": {"_typeName":"ManagedObjectReference","type":"PropertyCollector","value":"pc-1"},
+        "viewManager": {"_typeName":"ManagedObjectReference","type":"ViewManager","value":"vmgr-1"},
+        "about": {
+            "_typeName":"AboutInfo",
+            "name":"n",
+            "fullName":"f",
+            "vendor":"v",
+            "version":"1",
+            "build":"b",
+            "osType":"o",
+            "productLineId":"p",
+            "apiType":"VirtualCenter",
+            "apiVersion":"1"
+        }
+    }"#;
+    miniserde::json::from_str(json).expect("fixture ServiceContent")
+}
+
+#[cfg(test)]
+pub(crate) fn test_json_client_wire_transport() -> Arc<JsonClient> {
+    let base_url = format!("https://{}/sdk/vim25/{}", TEST_WIRE_DEAD_ADDR, API_RELEASE);
+    Arc::new(JsonClient {
+        http_client: test_dead_port_http_client(),
+        session_key: Arc::new(RwLock::new(None)),
+        api_release: API_RELEASE.to_string(),
+        base_url,
+        user_agent: "wire-transport-test".to_string(),
+        service_content: Some(test_minimal_service_content_for_tests()),
+        wire_logging: WireLoggingMode::Summary,
+    })
+}
+
+/// [`ServiceContent`] with `sessionManager` set (for JSON logout-on-`Drop` tests).
+#[cfg(test)]
+pub(crate) fn test_service_content_with_session_manager_for_tests() -> ServiceContent {
+    let json = r#"{
+        "_typeName": "ServiceContent",
+        "rootFolder": {"_typeName":"ManagedObjectReference","type":"Folder","value":"root-1"},
+        "propertyCollector": {"_typeName":"ManagedObjectReference","type":"PropertyCollector","value":"pc-1"},
+        "viewManager": {"_typeName":"ManagedObjectReference","type":"ViewManager","value":"vmgr-1"},
+        "sessionManager": {"_typeName":"ManagedObjectReference","type":"SessionManager","value":"sm-wire-test"},
+        "about": {
+            "_typeName":"AboutInfo",
+            "name":"n",
+            "fullName":"f",
+            "vendor":"v",
+            "version":"1",
+            "build":"b",
+            "osType":"o",
+            "productLineId":"p",
+            "apiType":"VirtualCenter",
+            "apiVersion":"1"
+        }
+    }"#;
+    miniserde::json::from_str(json).expect("fixture ServiceContent with session manager")
+}
+
+/// JSON VI client pointing at `http_origin` (e.g. `http://127.0.0.1:PORT`) for local stub servers.
+#[cfg(test)]
+pub(crate) fn test_json_client_http_origin(
+    http_origin: &str,
+    session_key: Option<String>,
+) -> Arc<JsonClient> {
+    let base_url = format!("{http_origin}/sdk/vim25/{API_RELEASE}");
+    Arc::new(JsonClient {
+        http_client: reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("reqwest test client"),
+        session_key: Arc::new(RwLock::new(session_key)),
+        api_release: API_RELEASE.to_string(),
+        base_url,
+        user_agent: "wire-http-test".to_string(),
+        service_content: Some(test_service_content_with_session_manager_for_tests()),
+        wire_logging: WireLoggingMode::Summary,
+    })
+}
+
+/// Wire logging integration tests: transport failures, HTTP error responses (`log_json_http_error`), and
+/// logout-on-`Drop` paths (JSON + SOAP). Uses a multi-threaded Tokio runtime for every async test because
+/// `JsonClient` / `SoapClient` `Drop` uses `block_in_place` + `block_on`. Serializes tests that share the
+/// global `log` sink and a localhost HTTP stub on a background OS thread for deterministic responses.
+#[cfg(test)]
+mod wire_logging_transport_tests {
+    use std::sync::{Mutex, Once};
+
+    use std::time::Instant;
+
+    use super::super::wire_log;
+    use super::{
+        test_dead_port_http_client, test_json_client_wire_transport, ClientBuilder, Error, JsonClient,
+        VimClient, WireLoggingMode, TEST_WIRE_DEAD_ADDR,
+    };
+    use miniserde::Serialize;
+
+    /// Matches [`crate::core::wire_log::TARGET_SOAP`] without importing the `xml`-gated symbol.
+    const SOAP_WIRE_TARGET: &str = "vim_rs::wire::soap";
+
+    static LOG_INIT: Once = Once::new();
+    static SERIAL: Mutex<()> = Mutex::new(());
+    static WIRE_LINES: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    struct CaptureWireLogger;
+
+    impl log::Log for CaptureWireLogger {
+        fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+            true
+        }
+
+        fn log(&self, record: &log::Record<'_>) {
+            let t = record.target();
+            if t == wire_log::TARGET_JSON || t == SOAP_WIRE_TARGET {
+                WIRE_LINES
+                    .lock()
+                    .expect("wire log capture")
+                    .push(record.args().to_string());
+            }
+        }
+
+        fn flush(&self) {}
+    }
+
+    fn init_wire_capture() {
+        LOG_INIT.call_once(|| {
+            let _ = log::set_logger(&CaptureWireLogger);
+            log::set_max_level(log::LevelFilter::Trace);
+        });
+    }
+
+    fn clear_wire_lines() {
+        WIRE_LINES.lock().expect("wire lines").clear();
+    }
+
+    fn joined_wire_output() -> String {
+        WIRE_LINES.lock().expect("wire lines").join("\n")
+    }
+
+    /// Empty JSON object `{}` for `invoke` paths that use a POST body.
+    struct EmptyJsonObject;
+    struct EmptyJsonMap;
+
+    impl Serialize for EmptyJsonObject {
+        fn begin(&self) -> miniserde::ser::Fragment<'_> {
+            miniserde::ser::Fragment::Map(Box::new(EmptyJsonMap))
+        }
+    }
+
+    impl miniserde::ser::Map for EmptyJsonMap {
+        fn next(&mut self) -> Option<(std::borrow::Cow<'_, str>, &dyn Serialize)> {
+            None
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_hello_negotiate_and_invoke_paths_log_transport_failure() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        // Hello System negotiation (no fixed api_release → must POST hello).
+        let hello_err = ClientBuilder::new(TEST_WIRE_DEAD_ADDR)
+            .http_client(test_dead_port_http_client())
+            .wire_logging(WireLoggingMode::Summary)
+            .build()
+            .await;
+        assert!(
+            matches!(hello_err.as_ref(), Err(Error::ReqwestError(_))),
+            "expected transport error from hello, got {:?}",
+            hello_err.as_ref().err()
+        );
+        let out = joined_wire_output();
+        assert!(
+            out.contains("phase=request kind=negotiate"),
+            "hello request line missing: {out}"
+        );
+        assert!(
+            out.contains("phase=response kind=negotiate") && out.contains("error=transport"),
+            "hello transport response line missing: {out}"
+        );
+
+        clear_wire_lines();
+        let jc = test_json_client_wire_transport();
+        let empty = EmptyJsonObject;
+
+        let invoke_err = jc
+            .invoke(
+                "",
+                "VirtualMachine",
+                "vm-1",
+                "RefreshStorageInfo",
+                Some(&empty as &(dyn Serialize + Send + Sync)),
+            )
+            .await;
+        assert!(matches!(invoke_err, Err(Error::ReqwestError(_))));
+        let out = joined_wire_output();
+        assert!(
+            out.contains("phase=request") && out.contains("method=RefreshStorageInfo"),
+            "invoke request missing: {out}"
+        );
+        assert!(
+            out.contains("phase=response") && out.contains("error=transport"),
+            "invoke transport response missing: {out}"
+        );
+
+        clear_wire_lines();
+        let opt_err = jc
+            .invoke_optional(
+                "",
+                "VirtualMachine",
+                "vm-1",
+                "SomeMethod",
+                Some(&empty as &(dyn Serialize + Send + Sync)),
+            )
+            .await;
+        assert!(matches!(opt_err, Err(Error::ReqwestError(_))));
+        let out = joined_wire_output();
+        assert!(out.contains("error=transport"), "invoke_optional: {out}");
+
+        clear_wire_lines();
+        let void_err = jc
+            .invoke_void("", "VirtualMachine", "vm-1", "Destroy", None)
+            .await;
+        assert!(matches!(void_err, Err(Error::ReqwestError(_))));
+        let out = joined_wire_output();
+        assert!(
+            out.contains("phase=request") && out.contains("body_bytes=0"),
+            "void request: {out}"
+        );
+        assert!(out.contains("error=transport"), "void transport: {out}");
+
+        clear_wire_lines();
+        let fetch_err = jc
+            .fetch_property_raw("", "VirtualMachine", "vm-1", "name")
+            .await;
+        assert!(matches!(fetch_err, Err(Error::ReqwestError(_))));
+        let out = joined_wire_output();
+        assert!(
+            out.contains("property=name") && out.contains("error=transport"),
+            "fetch_property_raw: {out}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_execute_void_helper_logs_transport_failure() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let jc = test_json_client_wire_transport();
+        let path_str = super::json_method_path("", "Folder", "group-d1", "Destroy");
+        let ctx = super::JsonWireCtx {
+            svc: "",
+            mo_type: "Folder",
+            mo_id: "group-d1",
+            name: "Destroy",
+            path: path_str.as_str(),
+            is_property_get: false,
+        };
+        let started = Instant::now();
+        let req = jc.build_post_request("", "Folder", "group-d1", "Destroy", None);
+        let req = jc.prepare(req).await;
+        let err = JsonClient::execute_void(jc.as_ref(), req, Some(ctx), started).await;
+        assert!(matches!(err, Err(Error::ReqwestError(_))));
+        let out = joined_wire_output();
+        assert!(out.contains("method=Destroy") && out.contains("error=transport"), "{out}");
+    }
+
+    #[cfg(feature = "xml")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_auto_probe_logs_transport_on_hello_send_failure() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let err = ClientBuilder::new(TEST_WIRE_DEAD_ADDR)
+            .http_client(test_dead_port_http_client())
+            .wire_logging(WireLoggingMode::Summary)
+            .transport(super::TransportMode::Auto)
+            .build()
+            .await;
+        assert!(err.is_err(), "expected auto build to fail");
+        let out = joined_wire_output();
+        assert!(
+            out.contains("kind=probe") && out.contains("error=transport"),
+            "auto probe transport line missing: {out}"
+        );
+    }
+
+    /// One-shot HTTP/1.1 stub on a background thread (avoids deadlocks with `Drop` + `block_on`).
+    fn spawn_http_stub_once(status: u16, body: &[u8]) -> (String, std::thread::JoinHandle<()>) {
+        use std::io::{Read, Write};
+        use std::net::TcpListener;
+        use std::thread;
+        use std::time::Duration;
+
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind http stub");
+        let port = listener.local_addr().expect("stub addr").port();
+        let body = body.to_vec();
+        let h = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("stub accept");
+            let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+            let mut buf = vec![0u8; 32768];
+            let _ = stream.read(&mut buf);
+            let status_text = match status {
+                200 => "OK",
+                403 => "Forbidden",
+                500 => "Internal Server Error",
+                503 => "Service Unavailable",
+                _ => "Error",
+            };
+            let head = format!(
+                "HTTP/1.1 {} {}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                status,
+                status_text,
+                body.len()
+            );
+            let mut out = head.into_bytes();
+            out.extend_from_slice(&body);
+            let _ = stream.write_all(&out);
+        });
+        (format!("http://127.0.0.1:{port}"), h)
+    }
+
+    /// Minimal [`MethodFault`] JSON (parses via `process_response`).
+    const SAMPLE_FAULT_JSON: &str = r#"{"_typeName":"VAppPropertyFault","id":"x","category":"string","label":"l","type":"string","value":"v"}"#;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_invoke_non_success_emits_wire_http_error_line() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let (origin, stub) = spawn_http_stub_once(500, SAMPLE_FAULT_JSON.as_bytes());
+        let jc = super::test_json_client_http_origin(&origin, Some("sess".into()));
+        let empty = EmptyJsonObject;
+        let err = jc
+            .invoke(
+                "",
+                "VirtualMachine",
+                "vm-1",
+                "SomeMethod",
+                Some(&empty as &(dyn Serialize + Send + Sync)),
+            )
+            .await;
+        assert!(matches!(err, Err(Error::MethodFault(_))));
+        stub.join().expect("stub thread");
+        let out = joined_wire_output();
+        assert!(out.contains("phase=request") && out.contains("method=SomeMethod"), "{out}");
+        assert!(
+            out.contains("status=500") && out.contains("phase=response"),
+            "expected log_json_http_error-style line: {out}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_fetch_property_non_success_emits_wire_http_error_line() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let (origin, stub) = spawn_http_stub_once(403, SAMPLE_FAULT_JSON.as_bytes());
+        let jc = super::test_json_client_http_origin(&origin, Some("sess".into()));
+        let err = jc
+            .fetch_property_raw("", "HostSystem", "host-9", "name")
+            .await;
+        assert!(matches!(err, Err(Error::MethodFault(_))));
+        stub.join().expect("stub thread");
+        let out = joined_wire_output();
+        assert!(out.contains("property=name") && out.contains("status=403"), "{out}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_drop_logout_emits_wire_lines_on_http_success() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let (origin, stub) = spawn_http_stub_once(200, b"");
+        let jc = super::test_json_client_http_origin(&origin, Some("sk-drop-ok".into()));
+        drop(jc);
+        stub.join().expect("stub thread");
+        let out = joined_wire_output();
+        assert!(out.contains("kind=logout") && out.contains("phase=request"), "{out}");
+        assert!(
+            out.contains("status=200") && !out.contains("error=http_failure"),
+            "{out}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_drop_logout_emits_wire_lines_on_http_non_success() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let (origin, stub) = spawn_http_stub_once(503, b"x");
+        let jc = super::test_json_client_http_origin(&origin, Some("sk-drop-bad".into()));
+        drop(jc);
+        stub.join().expect("stub thread");
+        let out = joined_wire_output();
+        assert!(
+            out.contains("kind=logout") && out.contains("error=http_failure"),
+            "{out}"
+        );
+        assert!(out.contains("status=503"), "{out}");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn json_drop_logout_emits_wire_transport_line() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let origin = format!("http://{}", super::TEST_WIRE_DEAD_ADDR);
+        let jc = super::test_json_client_http_origin(&origin, Some("sk-drop-tr".into()));
+        drop(jc);
+        let out = joined_wire_output();
+        assert!(
+            out.contains("kind=logout") && out.contains("error=transport"),
+            "{out}"
+        );
+    }
+
+    #[cfg(feature = "xml")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn soap_bootstrap_logs_transport_failure() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        use crate::xml::client::SoapClient;
+
+        let mut soap = SoapClient::new(
+            test_dead_port_http_client(),
+            TEST_WIRE_DEAD_ADDR,
+            super::API_RELEASE,
+            "soap-bootstrap-wire-test",
+            WireLoggingMode::Summary,
+        );
+        let err = soap.bootstrap().await;
+        assert!(matches!(err, Err(Error::ReqwestError(_))));
+        let out = joined_wire_output();
+        assert!(
+            out.contains("RetrieveServiceContent")
+                && out.contains("phase=request")
+                && out.contains("error=transport"),
+            "SOAP bootstrap wire: {out}"
+        );
+    }
+
+    #[cfg(feature = "xml")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn soap_invoke_logs_transport_failure() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        use crate::xml::client::soap_test_client_with_service_content;
+
+        let soap = soap_test_client_with_service_content();
+        let err = VimClient::invoke(
+            &soap,
+            "",
+            "VirtualMachine",
+            "vm-wire",
+            "RefreshStorageInfo",
+            None,
+        )
+        .await;
+        assert!(matches!(err, Err(Error::ReqwestError(_))));
+        let out = joined_wire_output();
+        assert!(
+            out.contains("RefreshStorageInfo") && out.contains("error=transport"),
+            "SOAP invoke wire: {out}"
+        );
+    }
+
+    #[cfg(feature = "xml")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn soap_drop_logout_emits_wire_on_http_success() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let (origin, stub) = spawn_http_stub_once(200, b"");
+        let endpoint = format!("{}/sdk", origin.trim_end_matches('/'));
+        let soap = crate::xml::client::soap_test_client_for_logout_drop(
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .build()
+                .unwrap(),
+            endpoint,
+        );
+        drop(soap);
+        stub.join().expect("stub thread");
+        let out = joined_wire_output();
+        assert!(
+            out.contains("wire=soap")
+                && out.contains("kind=logout")
+                && out.contains("status=200")
+                && !out.contains("error=http_failure"),
+            "{out}"
+        );
+    }
+
+    #[cfg(feature = "xml")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn soap_drop_logout_emits_wire_on_http_non_success() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let (origin, stub) = spawn_http_stub_once(502, b"err");
+        let endpoint = format!("{}/sdk", origin.trim_end_matches('/'));
+        let soap = crate::xml::client::soap_test_client_for_logout_drop(
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(5))
+                .build()
+                .unwrap(),
+            endpoint,
+        );
+        drop(soap);
+        stub.join().expect("stub thread");
+        let out = joined_wire_output();
+        assert!(
+            out.contains("error=http_failure") && out.contains("status=502"),
+            "{out}"
+        );
+    }
+
+    #[cfg(feature = "xml")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn soap_drop_logout_emits_wire_transport_line() {
+        let _serial = SERIAL.lock().expect("serial");
+        init_wire_capture();
+        clear_wire_lines();
+
+        let endpoint = format!("http://{}/sdk", super::TEST_WIRE_DEAD_ADDR);
+        let soap = crate::xml::client::soap_test_client_for_logout_drop(
+            reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(2))
+                .build()
+                .unwrap(),
+            endpoint,
+        );
+        drop(soap);
+        let out = joined_wire_output();
+        assert!(
+            out.contains("kind=logout") && out.contains("error=transport"),
+            "{out}"
+        );
     }
 }

--- a/vim_rs/src/core/mod.rs
+++ b/vim_rs/src/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub(crate) mod wire_log;
 pub mod error;
 pub(crate) mod helpers;
 pub mod pc_helpers;
@@ -9,6 +10,7 @@ mod root_objects;
 
 pub use client::Client;
 pub use client::ClientBuilder;
+pub use client::WireLoggingMode;
 pub use error::{Error, ErrorKind, Result};
 pub use root_objects::RootObjects;
 pub use root_objects::VsanObjectCatalog;

--- a/vim_rs/src/core/wire_log.rs
+++ b/vim_rs/src/core/wire_log.rs
@@ -1,0 +1,255 @@
+//! Dedicated wire logging for `vim_rs::wire::json` and `vim_rs::wire::soap` targets.
+//!
+//! Used by [`crate::core::client::JsonClient`] and (with the `xml` feature) SOAP client code.
+//! Summary-style records use [`log::Level::Debug`]; full bodies use [`log::Level::Trace`] when
+//! [`crate::core::client::WireLoggingMode::Detailed`] applies and the managed object is not
+//! `SessionManager`.
+
+use crate::core::client::WireLoggingMode;
+use log::Level;
+
+pub const TARGET_JSON: &str = "vim_rs::wire::json";
+#[cfg(feature = "xml")]
+pub const TARGET_SOAP: &str = "vim_rs::wire::soap";
+
+#[inline]
+pub(crate) fn bodies_allowed(mode: WireLoggingMode, mo_type: &str) -> bool {
+    matches!(mode, WireLoggingMode::Detailed) && mo_type != "SessionManager"
+}
+
+/// When detailed is selected but MO is denylisted, emit summary-style records with this marker.
+#[inline]
+pub(crate) fn body_logging_note(mode: WireLoggingMode, mo_type: &str) -> Option<&'static str> {
+    if matches!(mode, WireLoggingMode::Detailed) && mo_type == "SessionManager" {
+        Some("body_logging=denylisted")
+    } else {
+        None
+    }
+}
+
+#[inline]
+pub(crate) fn wire_mode_label(mode: WireLoggingMode, mo_type: &str) -> &'static str {
+    if matches!(mode, WireLoggingMode::Detailed) && mo_type == "SessionManager" {
+        "summary"
+    } else {
+        match mode {
+            WireLoggingMode::Off => "off",
+            WireLoggingMode::Summary => "summary",
+            WireLoggingMode::Detailed => "detailed",
+        }
+    }
+}
+
+fn level_for_wire_record(mode: WireLoggingMode, mo_type: &str, detailed_content: bool) -> Level {
+    if detailed_content && bodies_allowed(mode, mo_type) {
+        return Level::Trace;
+    }
+    Level::Debug
+}
+
+pub(crate) fn log_json_line(
+    mode: WireLoggingMode,
+    mo_type: &str,
+    detailed_content: bool,
+    msg: &str,
+) {
+    if !mode.is_enabled() {
+        return;
+    }
+    let level = level_for_wire_record(mode, mo_type, detailed_content);
+    log::log!(target: TARGET_JSON, level, "{}", msg);
+}
+#[cfg(feature = "xml")]
+pub(crate) fn log_soap_line(
+    mode: WireLoggingMode,
+    mo_type: &str,
+    detailed_content: bool,
+    msg: &str,
+) {
+    if !mode.is_enabled() {
+        return;
+    }
+    let level = level_for_wire_record(mode, mo_type, detailed_content);
+    log::log!(target: TARGET_SOAP, level, "{}", msg);
+}
+
+pub(crate) fn sanitize_utf8(bytes: &[u8]) -> std::borrow::Cow<'_, str> {
+    String::from_utf8_lossy(bytes)
+}
+
+/// Legacy transport `trace!` lines: omit when dedicated wire logging handles the same path.
+#[inline]
+pub(crate) fn suppress_legacy_transport_trace(wire: WireLoggingMode) -> bool {
+    wire.is_enabled()
+}
+
+pub(crate) fn log_json_http_error(
+    wire: WireLoggingMode,
+    svc: &str,
+    mo_type: &str,
+    mo_id: &str,
+    name: &str,
+    path: &str,
+    is_property_get: bool,
+    status: reqwest::StatusCode,
+    body: &str,
+    duration: std::time::Duration,
+) {
+    if !wire.is_enabled() {
+        return;
+    }
+    let mode_label = wire_mode_label(wire, mo_type);
+    let name_field = if is_property_get {
+        format!("property={}", name)
+    } else {
+        format!("method={}", name)
+    };
+    let note = body_logging_note(wire, mo_type);
+    let deny = note.unwrap_or("");
+    let deny_sep = if deny.is_empty() { "" } else { " " };
+    let body_part = if bodies_allowed(wire, mo_type) {
+        format!(" body={}", sanitize_utf8(body.as_bytes()))
+    } else {
+        String::new()
+    };
+    let msg = format!(
+        "wire=json mode={} phase=response svc=\"{}\" mo={} id={} {} path={} status={} body_bytes={} duration_ms={}{}{}{}",
+        mode_label,
+        svc,
+        mo_type,
+        mo_id,
+        name_field,
+        path,
+        status.as_u16(),
+        body.len(),
+        duration.as_millis(),
+        deny_sep,
+        deny,
+        body_part
+    );
+    let level = level_for_wire_record(wire, mo_type, !body_part.is_empty());
+    log::log!(target: TARGET_JSON, level, "{}", msg);
+}
+
+/// After a logged JSON request, emit a matching line when `send()` fails (DNS, TLS, connect, etc.).
+pub(crate) fn log_json_transport_failure(
+    wire: WireLoggingMode,
+    svc: &str,
+    mo_type: &str,
+    mo_id: &str,
+    name: &str,
+    path: &str,
+    is_property_get: bool,
+    duration: std::time::Duration,
+    err: &reqwest::Error,
+) {
+    if !wire.is_enabled() {
+        return;
+    }
+    let mode_label = wire_mode_label(wire, mo_type);
+    let name_field = if is_property_get {
+        format!("property={}", name)
+    } else {
+        format!("method={}", name)
+    };
+    let note = body_logging_note(wire, mo_type);
+    let deny = note.unwrap_or("");
+    let deny_sep = if deny.is_empty() { "" } else { " " };
+    let msg = format!(
+        "wire=json mode={} phase=response svc=\"{}\" mo={} id={} {} path={} error=transport duration_ms={}{}{} detail={}",
+        mode_label,
+        svc,
+        mo_type,
+        mo_id,
+        name_field,
+        path,
+        duration.as_millis(),
+        deny_sep,
+        deny,
+        err
+    );
+    let level = level_for_wire_record(wire, mo_type, false);
+    log::log!(target: TARGET_JSON, level, "{}", msg);
+}
+
+/// Hello negotiation (`build_json`): request was logged; pair with this on transport failure.
+pub(crate) fn log_json_negotiate_transport_failure(
+    wire: WireLoggingMode,
+    path: &str,
+    duration: std::time::Duration,
+    err: &reqwest::Error,
+) {
+    if !wire.is_enabled() {
+        return;
+    }
+    let mode_label = wire_mode_label(wire, "");
+    let msg = format!(
+        "wire=json mode={} phase=response kind=negotiate path={} error=transport body_bytes=0 duration_ms={} detail={}",
+        mode_label,
+        path,
+        duration.as_millis(),
+        err
+    );
+    let level = level_for_wire_record(wire, "", false);
+    log::log!(target: TARGET_JSON, level, "{}", msg);
+}
+
+#[cfg(feature = "xml")]
+pub(crate) fn log_soap_transport_failure(
+    wire: WireLoggingMode,
+    mo_type: &str,
+    mo_id: &str,
+    method_name: &str,
+    duration: std::time::Duration,
+    err: &reqwest::Error,
+) {
+    if !wire.is_enabled() {
+        return;
+    }
+    let mode_label = wire_mode_label(wire, mo_type);
+    let note = body_logging_note(wire, mo_type);
+    let deny = note.unwrap_or("");
+    let deny_sep = if deny.is_empty() { "" } else { " " };
+    let msg = format!(
+        "wire=soap mode={} phase=response mo={} id={} method={} error=transport duration_ms={}{}{} detail={}",
+        mode_label,
+        mo_type,
+        mo_id,
+        method_name,
+        duration.as_millis(),
+        deny_sep,
+        deny,
+        err
+    );
+    let level = level_for_wire_record(wire, mo_type, false);
+    log::log!(target: TARGET_SOAP, level, "{}", msg);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_manager_denies_bodies_in_detailed() {
+        assert!(!bodies_allowed(WireLoggingMode::Detailed, "SessionManager"));
+        assert!(bodies_allowed(WireLoggingMode::Detailed, "VirtualMachine"));
+    }
+
+    #[test]
+    fn body_logging_note_for_session_manager_detailed() {
+        assert_eq!(
+            body_logging_note(WireLoggingMode::Detailed, "SessionManager"),
+            Some("body_logging=denylisted")
+        );
+        assert_eq!(body_logging_note(WireLoggingMode::Summary, "SessionManager"), None);
+    }
+
+    #[test]
+    fn wire_mode_label_falls_back_for_session_manager_when_detailed() {
+        assert_eq!(
+            wire_mode_label(WireLoggingMode::Detailed, "SessionManager"),
+            "summary"
+        );
+    }
+
+}

--- a/vim_rs/src/lib.rs
+++ b/vim_rs/src/lib.rs
@@ -313,6 +313,7 @@ pub use vim_macros::vim_retrievable;
 pub use vim_macros::vim_updatable;
 
 pub mod core;
+pub use core::WireLoggingMode;
 pub mod types;
 
 pub mod mo;

--- a/vim_rs/src/xml/client.rs
+++ b/vim_rs/src/xml/client.rs
@@ -1,7 +1,11 @@
 use std::borrow::Cow;
+use std::time::Instant;
 
 use bytes::Bytes;
 use log::{debug, trace, warn};
+
+use crate::core::client::WireLoggingMode;
+use crate::core::wire_log;
 use miniserde::ser::{Fragment, Map as SerMap, Serialize};
 
 use crate::core::client::{BoxFuture, Error, PropertyValue, Result, Transport, VimClient};
@@ -131,18 +135,26 @@ pub(crate) struct SoapClient {
     user_agent: String,
     api_release: String,
     service_content: Option<ServiceContent>,
+    wire_logging: WireLoggingMode,
 }
 
 impl SoapClient {
     /// Create a new SoapClient. The `http_client` must be built with
     /// `.cookie_store(true)` for session management.
-    pub(crate) fn new(http_client: reqwest::Client, server_address: &str, api_release: &str, user_agent: &str) -> Self {
+    pub(crate) fn new(
+        http_client: reqwest::Client,
+        server_address: &str,
+        api_release: &str,
+        user_agent: &str,
+        wire_logging: WireLoggingMode,
+    ) -> Self {
         Self {
             http_client,
             endpoint: format!("https://{server_address}/sdk"),
             user_agent: user_agent.to_string(),
             api_release: api_release.to_string(),
             service_content: None,
+            wire_logging,
         }
     }
 
@@ -156,7 +168,54 @@ impl SoapClient {
             None,
         );
         let soap_body = super::soap::envelope(&method_xml);
-        let (status, body) = self.soap_post_raw(&soap_body).await?;
+        let started = Instant::now();
+        if self.wire_logging.is_enabled() {
+            let mode_l = wire_log::wire_mode_label(self.wire_logging, "ServiceInstance");
+            let msg = format!(
+                "wire=soap mode={} phase=request mo=ServiceInstance id=ServiceInstance method=RetrieveServiceContent endpoint={} body_bytes={}",
+                mode_l,
+                self.endpoint,
+                soap_body.len()
+            );
+            wire_log::log_soap_line(self.wire_logging, "ServiceInstance", false, &msg);
+        }
+        let resp = match self.soap_send_raw(&soap_body).await {
+            Ok(r) => r,
+            Err(e) => {
+                if self.wire_logging.is_enabled() {
+                    wire_log::log_soap_transport_failure(
+                        self.wire_logging,
+                        "ServiceInstance",
+                        "ServiceInstance",
+                        "RetrieveServiceContent",
+                        started.elapsed(),
+                        &e,
+                    );
+                }
+                return Err(Error::ReqwestError(e));
+            }
+        };
+        let status = resp.status();
+        let body = resp.text().await.map_err(Error::ReqwestError)?;
+        if self.wire_logging.is_enabled() {
+            let mode_l = wire_log::wire_mode_label(self.wire_logging, "ServiceInstance");
+            let mut msg = format!(
+                "wire=soap mode={} phase=response mo=ServiceInstance id=ServiceInstance method=RetrieveServiceContent status={} body_bytes={} duration_ms={}",
+                mode_l,
+                status.as_u16(),
+                body.len(),
+                started.elapsed().as_millis()
+            );
+            if wire_log::bodies_allowed(self.wire_logging, "ServiceInstance") {
+                msg.push_str(&format!(" body={}", body));
+            }
+            wire_log::log_soap_line(
+                self.wire_logging,
+                "ServiceInstance",
+                wire_log::bodies_allowed(self.wire_logging, "ServiceInstance"),
+                &msg,
+            );
+        }
         if !status.is_success() {
             let fault_msg = extract_soap_fault(&body).unwrap_or_else(|| format!("HTTP {status}"));
             return Err(Error::ParseError(format!(
@@ -170,19 +229,18 @@ impl SoapClient {
         Ok(())
     }
 
-    async fn soap_post_raw(&self, soap_body: &str) -> Result<(reqwest::StatusCode, String)> {
-        let resp = self
-            .http_client
+    async fn soap_send_raw(
+        &self,
+        soap_body: &str,
+    ) -> std::result::Result<reqwest::Response, reqwest::Error> {
+        self.http_client
             .post(&self.endpoint)
             .header("Content-Type", CONTENT_TYPE)
             .header("SOAPAction", format!("urn:vim25/{}", self.api_release))
             .header("User-Agent", &self.user_agent)
             .body(soap_body.to_owned())
             .send()
-            .await?;
-        let status = resp.status();
-        let body = resp.text().await?;
-        Ok((status, body))
+            .await
     }
 
     async fn soap_invoke(
@@ -194,11 +252,84 @@ impl SoapClient {
     ) -> Result<String> {
         let method_xml = build_soap_method_xml(method_name, mo_type, mo_id, params);
         let soap_body = super::soap::envelope(&method_xml);
-        if log::log_enabled!(log::Level::Trace) {
+        let started = Instant::now();
+        if self.wire_logging.is_enabled() {
+            let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+            let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+            let deny_s = deny.unwrap_or("");
+            let deny_sep = if deny_s.is_empty() { "" } else { " " };
+            let mut msg = format!(
+                "wire=soap mode={} phase=request mo={} id={} method={} endpoint={} body_bytes={}{}{}",
+                mode_l,
+                mo_type,
+                mo_id,
+                method_name,
+                self.endpoint,
+                soap_body.len(),
+                deny_sep,
+                deny_s
+            );
+            if wire_log::bodies_allowed(self.wire_logging, mo_type) {
+                msg.push_str(&format!(" body={}", soap_body));
+            }
+            wire_log::log_soap_line(
+                self.wire_logging,
+                mo_type,
+                wire_log::bodies_allowed(self.wire_logging, mo_type),
+                &msg,
+            );
+        } else if log::log_enabled!(log::Level::Trace)
+            && !wire_log::suppress_legacy_transport_trace(self.wire_logging)
+        {
             trace!("SOAP request for {}: {}", method_name, &soap_body);
         }
-        let (status, body) = self.soap_post_raw(&soap_body).await?;
-        if log::log_enabled!(log::Level::Trace) {
+        let resp = match self.soap_send_raw(&soap_body).await {
+            Ok(r) => r,
+            Err(e) => {
+                if self.wire_logging.is_enabled() {
+                    wire_log::log_soap_transport_failure(
+                        self.wire_logging,
+                        mo_type,
+                        mo_id,
+                        method_name,
+                        started.elapsed(),
+                        &e,
+                    );
+                }
+                return Err(Error::ReqwestError(e));
+            }
+        };
+        let status = resp.status();
+        let body = resp.text().await.map_err(Error::ReqwestError)?;
+        if self.wire_logging.is_enabled() {
+            let mode_l = wire_log::wire_mode_label(self.wire_logging, mo_type);
+            let deny = wire_log::body_logging_note(self.wire_logging, mo_type);
+            let deny_s = deny.unwrap_or("");
+            let deny_sep = if deny_s.is_empty() { "" } else { " " };
+            let mut msg = format!(
+                "wire=soap mode={} phase=response mo={} id={} method={} status={} body_bytes={} duration_ms={}{}{}",
+                mode_l,
+                mo_type,
+                mo_id,
+                method_name,
+                status.as_u16(),
+                body.len(),
+                started.elapsed().as_millis(),
+                deny_sep,
+                deny_s
+            );
+            if wire_log::bodies_allowed(self.wire_logging, mo_type) {
+                msg.push_str(&format!(" body={}", body));
+            }
+            wire_log::log_soap_line(
+                self.wire_logging,
+                mo_type,
+                wire_log::bodies_allowed(self.wire_logging, mo_type),
+                &msg,
+            );
+        } else if log::log_enabled!(log::Level::Trace)
+            && !wire_log::suppress_legacy_transport_trace(self.wire_logging)
+        {
             trace!("SOAP response {} from {}: {}", status, method_name, &body);
         }
         if !status.is_success() {
@@ -374,11 +505,24 @@ impl Drop for SoapClient {
         let http_client = self.http_client.clone();
         let endpoint = self.endpoint.clone();
         let user_agent = self.user_agent.clone();
+        let wire_logging = self.wire_logging;
 
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async move {
                 let method_xml = build_soap_method_xml("Logout", "SessionManager", &sm_value, None);
                 let soap_body = super::soap::envelope(&method_xml);
+                if wire_logging.is_enabled() {
+                    let mode_l = wire_log::wire_mode_label(wire_logging, "SessionManager");
+                    let msg = format!(
+                        "wire=soap mode={} phase=request kind=logout mo=SessionManager id={} method=Logout endpoint={} body_bytes={} body_logging=denylisted",
+                        mode_l,
+                        sm_value,
+                        endpoint,
+                        soap_body.len()
+                    );
+                    wire_log::log_soap_line(wire_logging, "SessionManager", false, &msg);
+                }
+                let started = Instant::now();
                 match http_client
                     .post(&endpoint)
                     .header("Content-Type", CONTENT_TYPE)
@@ -388,13 +532,46 @@ impl Drop for SoapClient {
                     .send()
                     .await
                 {
-                    Ok(resp) if resp.status().is_success() => {
-                        debug!("SOAP session logged out successfully");
-                    }
                     Ok(resp) => {
-                        warn!("SOAP logout failed (HTTP {})", resp.status());
+                        let status = resp.status();
+                        let body = resp.text().await.unwrap_or_default();
+                        let dur = started.elapsed();
+                        if wire_logging.is_enabled() {
+                            let mode_l = wire_log::wire_mode_label(wire_logging, "SessionManager");
+                            let http_note = if status.is_success() {
+                                ""
+                            } else {
+                                " error=http_failure"
+                            };
+                            let msg = format!(
+                                "wire=soap mode={} phase=response kind=logout mo=SessionManager id={} method=Logout status={} body_bytes={} duration_ms={} body_logging=denylisted{}",
+                                mode_l,
+                                sm_value,
+                                status.as_u16(),
+                                body.len(),
+                                dur.as_millis(),
+                                http_note
+                            );
+                            wire_log::log_soap_line(wire_logging, "SessionManager", false, &msg);
+                        }
+                        if status.is_success() {
+                            debug!("SOAP session logged out successfully");
+                        } else {
+                            warn!("SOAP logout failed (HTTP {})", status);
+                        }
                     }
                     Err(e) => {
+                        if wire_logging.is_enabled() {
+                            let mode_l = wire_log::wire_mode_label(wire_logging, "SessionManager");
+                            let msg = format!(
+                                "wire=soap mode={} phase=response kind=logout mo=SessionManager id={} method=Logout error=transport duration_ms={} body_logging=denylisted detail={}",
+                                mode_l,
+                                sm_value,
+                                started.elapsed().as_millis(),
+                                e
+                            );
+                            wire_log::log_soap_line(wire_logging, "SessionManager", false, &msg);
+                        }
                         warn!("SOAP logout request failed: {}", e);
                     }
                 }
@@ -447,3 +624,38 @@ impl<'a> SerMap for FetchPropertyRequestMap<'a> {
         }
     }
 }
+
+#[cfg(all(test, feature = "xml"))]
+pub(crate) fn soap_test_client_with_service_content() -> SoapClient {
+    use crate::core::client::{WireLoggingMode, API_RELEASE, TEST_WIRE_DEAD_ADDR};
+    use crate::core::client::{test_dead_port_http_client, test_minimal_service_content_for_tests};
+    let mut c = SoapClient::new(
+        test_dead_port_http_client(),
+        TEST_WIRE_DEAD_ADDR,
+        API_RELEASE,
+        "wire-soap-transport-test",
+        WireLoggingMode::Summary,
+    );
+    c.service_content = Some(test_minimal_service_content_for_tests());
+    c
+}
+
+/// SOAP client with `service_content` + `sessionManager` and a caller-supplied endpoint (for logout `Drop` tests).
+#[cfg(all(test, feature = "xml"))]
+pub(crate) fn soap_test_client_for_logout_drop(
+    http_client: reqwest::Client,
+    endpoint: String,
+) -> SoapClient {
+    use crate::core::client::WireLoggingMode;
+    SoapClient {
+        http_client,
+        endpoint,
+        user_agent: "soap-logout-wire-test".to_string(),
+        api_release: crate::core::client::API_RELEASE.to_string(),
+        service_content: Some(
+            crate::core::client::test_service_content_with_session_manager_for_tests(),
+        ),
+        wire_logging: WireLoggingMode::Summary,
+    }
+}
+


### PR DESCRIPTION
### Added

- **Wire logging:** `ClientBuilder::wire_logging` and `WireLoggingMode` for opt-in transport diagnostics on dedicated log targets (`vim_rs::wire::json`, `vim_rs::wire::soap`). Defaults to **`Off`**; no behavior change unless you enable it.
  - **`WireLoggingMode::Summary`** — request/response metadata (sizes, paths, status, duration) at [`log::Level::Debug`].
  - **`WireLoggingMode::Detailed`** — may include full request/response bodies at [`log::Level::Trace`] where allowed.
  - **`SessionManager`** traffic (login, logout, session APIs) never logs bodies in detailed mode; logs stay summary-style with `body_logging=denylisted` / `mode=summary` as applicable.
  - Import: `use vim_rs::WireLoggingMode;` (also available as `vim_rs::core::WireLoggingMode`).
  - Typical filters: `RUST_LOG=vim_rs::wire::json=debug`, `vim_rs::wire::soap=debug`; use `=trace` on a target only when you need detailed bodies.

### Changed

- **BREAKING:** `RootObjects` and `VsanObjectCatalog` now hold `VimClientHandle` (`Arc<dyn VimClient>`) instead of `Arc<Client>`. `RootObjects::new` / `VsanObjectCatalog::new` still accept `Arc<Client>` via coercion to the trait object. `RootObjects::client()` and `VsanObjectCatalog::client()` now return `VimClientHandle`; code that required `Arc<Client>` from those accessors must keep the concrete handle separately or adjust types.
- `CacheManager::new` and `new_with_property_collector` use `Arc<dyn VimClient>` in their signatures (equivalent to the existing `VimClientHandle` alias).
- `ObjectRetriever::new` uses `Arc<dyn VimClient>`
- **Wire logging:** When wire logging is not [`WireLoggingMode::Off`], legacy transport-oriented `trace!` lines that dump request/response payloads are **not** emitted for the same paths (dedicated `vim_rs::wire::*` logs are authoritative). Other library `debug!` / `trace!` diagnostics are unchanged.
