### PR TITLE
feat(client): selectable TLS via default-client and reqwest 0.13 (#37)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-metadata-xml-de"
+  "feature_directory": "specs/002-selectable-tls-backend"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`default-client` Cargo feature** (enabled by default): turnkey `ClientBuilder` auto-creates a `reqwest` client and supports `insecure(true)` / `http_client()` overrides. Disable with `default-features = false` and pass your own `reqwest::Client` to `ClientBuilder::new(server, client)` (compile-time required client when opted out). See `examples/tls_rustls_only`.
+
 ### Changed
 
+- **reqwest 0.13** with `default-features = false` on the dependency; turnkey builds enable `reqwest/default` via `default-client` (TLS backend is **rustls**, not OpenSSL — **breaking** for binaries that relied on linking `openssl-sys` through the old default). Default-feature `vim_rs` / `examples/vtui` build-time and binary-size deltas were not measured for this release.
+- **`reqwest/cookies`** is enabled only with the `xml` feature; VI/JSON session auth uses the `vmware-api-session-id` header, not HTTP cookies. Auto-built clients call `.cookie_store(true)` only on the SOAP path.
 - **SOAP/XML (`xml` feature):** Enrich codegen (api_field_registry, data_type_aware) and rewrite xml/de.rs so the driver follows declared types. Add Spec Kit docs and changelog note for 001-metadata-xml-de. Support for non-"vim" namespaces is absent.
 
 ## [0.4.4] - 2026-04-18

--- a/README.md
+++ b/README.md
@@ -53,11 +53,60 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 You can add `insecure()` to your builder configuration to bypass TLS checks for both hostname and certificate.
 
-One can set the `reqwest` preconfigured client through the builder's `http_client` method to reuse the `reqwest` connection and connection settings. The `vim_rs` client abstraction is cheap, but the `reqwest` HTTP client is not.
+One can set a preconfigured `reqwest` client through the builder's `http_client()` method to reuse connections and TLS settings without disabling default features. The `vim_rs` client abstraction is cheap, but the `reqwest` HTTP client is not.
 
 The `client` above is an `Arc` around the actual client object. Use `.clone()` to pass it around.
 
 If the above goes well, you have a connection to the vCenter server with an initialized session and retrieved service content.
+
+### TLS backend and opting out of the default HTTP client
+
+By default, `vim_rs` enables the **`default-client`** feature, which enables `reqwest/default` (**rustls** for TLS on reqwest 0.13 — not OpenSSL — plus `charset`, `http2`, and `system-proxy`). To pick your own TLS stack (for example **native-tls**/OpenSSL, or rustls with **ring** instead of the default aws-lc-rs provider), use `default-features = false` and pass a `reqwest::Client` to `ClientBuilder::new(server, client)`.
+
+With **`default-features = false`**, `ClientBuilder::new` requires `(server, reqwest::Client)`; `insecure()` and `http_client()` are not on the builder — configure TLS and proxies on your `reqwest` client instead. For self-signed certs, use `danger_accept_invalid_certs` and `danger_accept_invalid_hostnames` on the reqwest builder (same effect as turnkey `.insecure(true)`).
+
+**VI/JSON only** (vCenter JSON API; sessions use the `vmware-api-session-id` header — no HTTP cookies):
+
+```toml
+vim_rs = { version = "0.4", default-features = false }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+# Often useful (reqwest defaults when default-client is on): "charset", "http2", "system-proxy"
+```
+
+```rust
+use vim_rs::core::ClientBuilder;
+
+let http = reqwest::Client::builder().build()?;
+let client = ClientBuilder::new("vcenter.example.com", http)
+    .basic_authn("administrator@vsphere.local", "password")
+    .app_details(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+    .build()
+    .await?;
+```
+
+**SOAP/XML** (ESXi or `TransportMode::Soap` / `Auto`; enable `vim_rs` **`xml`** and reqwest **`cookies`**, and call `.cookie_store(true)` on your client):
+
+```toml
+vim_rs = { version = "0.4", default-features = false, features = ["xml"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "cookies", "charset", "http2", "system-proxy"] }
+```
+
+```rust
+use vim_rs::core::ClientBuilder;
+use vim_rs::core::client::TransportMode;
+
+let http = reqwest::Client::builder().cookie_store(true).build()?;
+let client = ClientBuilder::new("esxi.example.com", http)
+    .basic_authn("root", "password")
+    .app_details(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+    .transport(TransportMode::Soap)
+    .build()
+    .await?;
+```
+
+See [`tls_rustls_only`](tls_rustls_only) for an OpenSSL-free dependency graph using `rustls-no-provider` plus a separate `rustls` crate with the **ring** provider (instead of `features = ["rustls"]` alone).
+
+To check for OpenSSL in the graph, run `cargo tree -i openssl-sys` from your crate directory. **No `openssl-sys` in the tree is the expected good outcome** — Cargo prints `error: package ID specification 'openssl-sys' did not match any packages` and exits with code 101. That message is not a failed build; it means the inverse query found nothing. If `openssl-sys` were present, you would see a tree rooted at that package instead.
 
 ### Wire logging (transport diagnostics)
 
@@ -624,3 +673,6 @@ On a good machine, the first-time compilation of vim-tests can take between 2 an
 
 **Why does the design use a hybrid approach with both traits and enums?**  
 The VIM API is inherently polymorphic, and while enums are safe and idiomatic in Rust, using only enums would lead to unwieldy type definitions. The hybrid approach—with traits for the deep hierarchical parts and enums for simpler aspects—strikes a balance between performance and usability.
+
+**Why does ESX authentication fail?**  
+For SOAP/XML against ESXi, enable the `vim_rs` **`xml`** feature, enable reqwest's **`cookies`** feature, and call `.cookie_store(true)` on `reqwest::Client::builder()` before `build()`. VI/JSON to vCenter does not use HTTP cookies. If you opted out of `default-client`, you must supply the configured client to `ClientBuilder::new(server, http_client)`.

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,9 +49,9 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -99,9 +99,31 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -132,9 +154,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -147,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -174,11 +196,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -208,16 +232,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
-name = "compact_str"
-version = "0.9.0"
+name = "combine"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -306,7 +349,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -431,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -456,10 +499,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "either"
-version = "1.15.0"
+name = "dunce"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -472,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
@@ -482,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -527,12 +576,6 @@ dependencies = [
  "bit-set",
  "regex",
 ]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "filedescriptor"
@@ -582,21 +625,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,6 +632,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -710,8 +744,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -721,9 +757,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -741,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -779,6 +817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,9 +836,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -831,9 +875,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -845,7 +889,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -853,33 +896,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -934,12 +960,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -947,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -960,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -974,15 +1001,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -994,15 +1021,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1038,9 +1065,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1048,12 +1075,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1087,16 +1114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,9 +1136,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -1132,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1142,11 +1159,72 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.91"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1182,17 +1260,17 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1203,9 +1281,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1224,18 +1302,24 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -1249,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memmem"
@@ -1304,9 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -1315,29 +1399,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1356,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -1402,47 +1469,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.116"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -1562,7 +1592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1603,18 +1633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,18 +1640,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1643,6 +1661,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1681,11 +1708,67 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1715,7 +1798,27 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1723,6 +1826,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "ratatui"
@@ -1744,7 +1856,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
@@ -1796,7 +1908,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.16.1",
  "indoc",
  "instability",
@@ -1815,7 +1927,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1849,9 +1961,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -1865,21 +1977,19 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1904,6 +2014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,7 +2034,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1927,10 +2043,11 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1939,13 +2056,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
+name = "rustls-native-certs"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1953,6 +2110,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1969,6 +2127,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1991,7 +2158,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2010,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2046,27 +2213,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -2082,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -2118,6 +2273,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simplelog"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,9 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2162,9 +2333,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2263,7 +2434,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2276,19 +2447,6 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2329,7 +2487,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -2438,19 +2596,34 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
 ]
 
 [[package]]
-name = "tokio"
-version = "1.50.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2463,23 +2636,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2522,20 +2685,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2588,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -2606,9 +2769,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
@@ -2665,21 +2828,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2747,6 +2904,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,11 +2930,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -2776,14 +2943,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2794,23 +2961,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2818,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2831,9 +2994,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -2866,7 +3029,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -2874,12 +3037,31 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3061,7 +3243,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3079,14 +3270,31 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -3096,10 +3304,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3108,10 +3328,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3120,10 +3352,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3132,10 +3376,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -3145,6 +3401,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -3195,7 +3457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -3227,15 +3489,15 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3244,9 +3506,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3255,19 +3517,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.6"
+name = "zerocopy"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3283,9 +3565,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3294,9 +3576,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3305,9 +3587,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie",
+ "cookie 0.16.2",
  "derive_more",
  "encoding_rs",
  "foldhash 0.1.5",
@@ -190,7 +190,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "time",
  "tracing",
  "url",
@@ -404,9 +404,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "av-scenechange"
@@ -423,7 +423,7 @@ dependencies = [
  "num-traits",
  "pastey 0.1.1",
  "rayon",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "y4m",
 ]
@@ -444,18 +444,18 @@ dependencies = [
 
 [[package]]
 name = "avif-serialize"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
 ]
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -508,17 +508,17 @@ checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitstream-io"
-version = "4.9.0"
+version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
 dependencies = [
- "core2",
+ "no_std_io2",
 ]
 
 [[package]]
@@ -541,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -552,9 +552,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -581,7 +581,7 @@ dependencies = [
  "convert_case 0.10.0",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
  "vim_build",
 ]
@@ -611,15 +611,15 @@ dependencies = [
 
 [[package]]
 name = "built"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -647,9 +647,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytestring"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
 ]
@@ -665,21 +665,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -760,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -782,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -800,9 +794,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -831,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -846,15 +840,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -893,6 +886,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie 0.18.1",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,15 +939,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -997,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1075,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 dependencies = [
  "serde",
 ]
@@ -1190,13 +1203,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1222,13 +1235,22 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1245,9 +1267,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encode_unicode"
@@ -1323,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "fastembed"
-version = "5.13.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3688aa7e02113db24e0f83aba1edee912f36f515b52cffc9b3c550bbfc3eab87"
+checksum = "c65faeb787d66e812248f992693268eee8a43a95e3e43e0c33547f1c8391ecce"
 dependencies = [
  "anyhow",
  "hf-hub",
@@ -1340,29 +1362,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1587,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -1640,16 +1648,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1691,6 +1699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1698,23 +1712,23 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hf-hub"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
  "dirs",
- "http 1.4.0",
+ "http 1.4.1",
  "indicatif",
  "libc",
  "log",
  "native-tls",
- "rand 0.9.3",
+ "rand 0.9.4",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
- "ureq 2.12.1",
- "windows-sys 0.60.2",
+ "thiserror",
+ "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1736,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1751,7 +1765,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1762,7 +1776,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "pin-project-lite",
 ]
@@ -1796,30 +1810,29 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1827,15 +1840,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1867,14 +1879,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1908,12 +1920,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1921,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1934,9 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1948,15 +1961,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1968,15 +1981,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2012,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2072,9 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "impl-more"
@@ -2084,26 +2097,26 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2123,16 +2136,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2157,25 +2160,52 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2189,10 +2219,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2223,9 +2255,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2245,9 +2277,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
 ]
@@ -2260,9 +2292,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "local-channel"
@@ -2292,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "loop9"
@@ -2313,9 +2351,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+checksum = "e20f57f9918e5bd7bc58c22cdd70a6afc7375d4dd9683af5f2b34bd3d2bba619"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -2355,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -2393,9 +2431,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -2474,6 +2512,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2528,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2573,12 +2620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,9 +2633,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
  "bitflags",
  "libc",
@@ -2604,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2619,7 +2660,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -2673,26 +2714,26 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5df903c0d2c07b56950f1058104ab0c8557159f2741782223704de9be73c3c"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
  "ndarray",
  "ort-sys",
  "smallvec",
  "tracing",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06503bb33f294c5f1ba484011e053bfa6ae227074bdb841e9863492dc5960d4b"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
  "lzma-rust2",
- "ureq 3.3.0",
+ "ureq",
 ]
 
 [[package]]
@@ -2741,9 +2782,9 @@ checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pastey"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2881,16 +2922,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -2913,18 +2948,18 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2965,18 +3000,18 @@ dependencies = [
 
 [[package]]
 name = "profiling"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
 ]
 
 [[package]]
 name = "profiling-procmacros"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn",
@@ -2984,9 +3019,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14104c5a24d9bcf7eb2c24753e0f49fe14555d8bd565ea3d38e4b4303267259d"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "getopts",
@@ -3003,9 +3038,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -3035,8 +3070,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
- "thiserror 2.0.18",
+ "socket2 0.6.4",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3052,13 +3087,13 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3073,7 +3108,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3112,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3202,10 +3237,10 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
- "thiserror 2.0.18",
+ "thiserror",
  "v_frame",
  "wasm-bindgen",
 ]
@@ -3233,9 +3268,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3279,7 +3314,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3348,8 +3383,8 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3382,16 +3417,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3442,21 +3477,21 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.4.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
  "futures",
- "pastey 0.2.1",
+ "pastey 0.2.3",
  "pin-project-lite",
  "rmcp-macros",
  "schemars",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3464,9 +3499,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3477,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3505,9 +3540,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3521,9 +3556,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3533,9 +3568,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3543,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -3678,9 +3713,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -3725,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -3756,7 +3791,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3781,9 +3816,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3797,9 +3832,19 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
 
 [[package]]
 name = "simd_helpers"
@@ -3811,10 +3856,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
+name = "simdutf8"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3850,9 +3901,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3994,31 +4045,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -4088,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4130,7 +4161,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rayon",
  "rayon-cond",
  "regex",
@@ -4138,7 +4169,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 2.0.18",
+ "thiserror",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -4146,9 +4177,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4156,16 +4187,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4222,20 +4253,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -4316,9 +4347,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -4349,9 +4380,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4372,30 +4403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "flate2",
- "log",
- "native-tls",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "url",
- "webpki-roots 0.26.11",
-]
 
 [[package]]
 name = "ureq"
@@ -4404,15 +4421,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64 0.22.1",
+ "cookie_store",
  "der",
+ "flate2",
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "socks",
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4422,7 +4445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -4505,7 +4528,7 @@ dependencies = [
  "phf_codegen",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4525,13 +4548,13 @@ dependencies = [
  "pulldown-cmark",
  "rayon",
  "regex",
- "reqwest 0.13.2",
+ "reqwest 0.13.4",
  "rmcp",
  "schemars",
  "serde",
  "serde_json",
  "tera",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4565,11 +4588,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -4578,14 +4601,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4596,23 +4619,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4620,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4633,9 +4652,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4689,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4709,27 +4728,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4843,27 +4853,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -4884,21 +4876,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -4936,12 +4913,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4954,12 +4925,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4969,12 +4934,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5002,12 +4961,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5017,12 +4970,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5038,12 +4985,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5053,12 +4994,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5080,6 +5015,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5162,9 +5103,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "y4m"
@@ -5174,9 +5115,9 @@ checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5185,9 +5126,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5197,18 +5138,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5217,18 +5158,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5244,9 +5185,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5255,9 +5196,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5266,9 +5207,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5326,9 +5267,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
 ]

--- a/specs/002-selectable-tls-backend/checklists/requirements.md
+++ b/specs/002-selectable-tls-backend/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Selectable TLS Backend / Opt-Out of Default Client Configuration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-06-01
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [ ] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [ ] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`.
+- **Content Quality / "No implementation details"** is intentionally left unchecked: this is a library dependency-wiring and TLS-backend feature, so the spec necessarily references the HTTP client crate, its TLS backends, feature flags, and `core/client.rs`. These are the subject matter of the feature (the issue is itself a `Cargo.toml`/feature request), not incidental tech leakage. Success criteria remain outcome-based (dependency-tree contents, cross-compile, behavior parity).
+- **Clarification resolved (2026-06-01)**: Turnkey TLS default strategy (FR-011/FR-012) — the turnkey path enables the HTTP client crate's default feature set, so on 0.13 the default backend becomes rustls; `vim_rs` does not pin native-TLS and does not expose per-backend toggles. Documented as a notable change. No `[NEEDS CLARIFICATION]` markers remain.
+- **Clarification resolved (2026-06-01)**: Opt-out HTTP client (FR-003/FR-006/FR-009) — `ClientBuilder::new(server, http_client)` required when `default-client` is off; compile-time enforcement; `http_client()` override only on turnkey path.
+- **Clarification resolved (2026-06-01)**: Cookie store (FR-007/FR-008) — `.cookie_store(true)` and `reqwest/cookies` only for `xml`/SOAP; VI/JSON uses `vmware-api-session-id` header, not cookies. Corrects earlier mistaken “cookies required for JSON” wording.

--- a/specs/002-selectable-tls-backend/contracts/README.md
+++ b/specs/002-selectable-tls-backend/contracts/README.md
@@ -1,0 +1,65 @@
+# Contracts: HTTP client & TLS configuration
+
+**Feature**: [spec.md](../spec.md) | **Plan**: [plan.md](../plan.md)
+
+Public behavior for **`vim_rs`** consumers around **`ClientBuilder`**, Cargo features, and **`reqwest`**.
+
+## Cargo features
+
+| Feature | Default | Contract |
+|---------|---------|----------|
+| **`default-client`** | yes (via `default`) | Enables `reqwest/default` (TLS + reqwest default non-TLS pieces). Auto-creates HTTP client when none injected. Exposes `ClientBuilder::insecure`. |
+| **`defaults`** | no | Unrelated: generates `Default` impls for types (existing). |
+| **`xml`** | no | SOAP/XML transport; does **not** gate `reqwest/cookies`. |
+| **`vcsim_compat`** | no | Implies `xml` (existing). |
+
+**Opt-out manifest**:
+
+```toml
+vim_rs = { version = "0.5", default-features = false }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "charset", "http2", "system-proxy", "cookies"] }
+```
+
+Consumer **must** pass `reqwest::Client` to **`ClientBuilder::new(server, client)`** (feature-gated signature).
+
+## `ClientBuilder` API
+
+| Method | `default-client` on | `default-client` off |
+|--------|----------------------|----------------------|
+| `new(server)` | Available | **Not available** |
+| `new(server, http_client)` | **Not available** | **Required** |
+| `transport`, `basic_authn`, `app_details`, `locale`, `wire_logging`, `api_release`, … | Available | Available |
+| `http_client(client)` | Optional override before `build()` | **Not compiled** (`cfg`) |
+| `insecure(bool)` | Available; affects auto-built client | **Not compiled** (`cfg`) |
+| `build().await` | Auto-builds client if none injected | Uses client from `new`; no auto-build |
+
+**Injected client**: Same behavior whether or not `default-client` is enabled (FR-009). TLS, proxies, timeouts, and cookie store are the consumer’s responsibility when injecting.
+
+## TLS behavior
+
+| Build | Linked TLS (typical Linux) | Trust roots |
+|-------|---------------------------|-------------|
+| Default (`default-client`) | **rustls** (reqwest 0.13 default) | OS / platform verifier |
+| Opt-out + consumer `rustls` | rustls only | Consumer’s reqwest config |
+| Opt-out + consumer `native-tls` | native-tls + OpenSSL | Consumer’s choice |
+
+**Breaking change (0.5+)**: Turnkey builds that previously linked **OpenSSL** via reqwest 0.12 now link **rustls** by default. Documented in **CHANGELOG** / **README**.
+
+## SOAP/XML (`xml` feature)
+
+| Mode | Cookie store |
+|------|----------------|
+| Turnkey + `default-client` + SOAP | Auto-built client uses `cookie_store(true)` |
+| Opt-out + SOAP | Consumer’s injected client **must** use `.cookie_store(true)` |
+
+## Error contract
+
+| Condition | Result |
+|-----------|--------|
+| Opt-out, `new` without `http_client` | **Compile error** (wrong `new` signature / missing argument) |
+| Network / HTTP failures | Unchanged (`ReqwestError`, `MethodFault`, …) |
+
+## Non-goals (stable)
+
+- No `vim_rs` feature to pick `native-tls` vs `rustls` without opting out.
+- No change to wire logging targets, session header auth, or transport method semantics.

--- a/specs/002-selectable-tls-backend/data-model.md
+++ b/specs/002-selectable-tls-backend/data-model.md
@@ -1,0 +1,100 @@
+# Data model: Client configuration & feature wiring
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+This feature is dependency- and builder-state wiring, not persistent storage. “Entities” below are **configuration concepts** and **builder state**.
+
+---
+
+## Entities
+
+### `default-client` (Cargo feature)
+
+| Attribute | Description |
+|-----------|-------------|
+| **Default** | Enabled via `vim_rs` `default = ["default-client"]` |
+| **Enables** | `reqwest/default` on the dependency graph → TLS + charset + http2 + system-proxy (reqwest 0.13: TLS = rustls) |
+| **Code effect** | `#[cfg(feature = "default-client")]` blocks: auto `reqwest::Client` creation, `ClientBuilder::insecure` |
+| **When disabled** | Consumer must inject `reqwest::Client`; no `openssl-sys` from `vim_rs` unless consumer adds `native-tls` |
+
+### `ClientBuilder` (runtime)
+
+| Field / concern | Role |
+|-----------------|------|
+| `http_client: Option<reqwest::Client>` | Turnkey: optional until `build()` (auto-create if `None`). Opt-out: **always `Some`** — set in `new(server, client)` |
+| `insecure: Option<bool>` | Only meaningful with `default-client`; passed to shared `build_default_http_client` |
+| `transport_mode` | Json / Soap / Auto — unchanged |
+| Other fields | `server_address`, auth, API release, wire logging — unchanged |
+
+**State transitions (build)**:
+
+```text
+[default-client ON, http_client None]
+  → build_default_http_client(insecure, cookie_store per path)
+  → connected Client
+
+[default-client ON, http_client Some]
+  → use injected client (insecure on builder ignored for TLS — existing behavior)
+
+[default-client OFF]
+  → new(server, http_client) only (FR-006); http_client always present
+
+[default-client OFF, invalid API use]
+  → compile error (e.g. calling turnkey-only `new(server)`)
+```
+
+### `build_default_http_client` (internal helper)
+
+| Parameter | JSON path | SOAP path | Auto probe |
+|-----------|-----------|-----------|------------|
+| `insecure` | from builder | from builder | from builder |
+| `cookie_store` | `false` (VI/JSON uses header session) | `true` (SOAP only) | `false` (Hello probe) |
+
+**Validation**: `insecure == true` logs existing warning; applies `tls_danger_accept_invalid_*` on builder.
+
+### `reqwest` dependency (manifest)
+
+| Always-on features (base dep) | Via `default-client` | Via `xml` |
+|------------------------------|----------------------|-----------|
+| `charset`, `http2`, `system-proxy` | `default` → `default-tls` → `rustls` | `cookies` (for `.cookie_store`) |
+
+### `xml` feature
+
+| Attribute | Value |
+|-----------|-------|
+| Enables | `quick-xml`, `reqwest/cookies` |
+| Auto-build | `build_default_http_client(..., cookie_store: true)` on SOAP path only |
+
+### `Error` (extension)
+
+No new error variant for missing HTTP client in opt-out mode — prevented at compile time (FR-006).
+
+Existing `ReqwestError`, `MethodFault`, etc. unchanged.
+
+---
+
+## Relationships
+
+```text
+Consumer Cargo.toml
+  ├─ default-features = true  → vim_rs/default-client → reqwest/default → rustls
+  └─ default-features = false → no reqwest TLS from vim_rs
+        └─ consumer reqwest + ClientBuilder::http_client(...)
+
+ClientBuilder
+  └─ build() → JsonClient | SoapClient (via Client facade)
+        └─ holds reqwest::Client (owned or injected)
+```
+
+---
+
+## Validation rules (from spec)
+
+| Rule | Enforcement |
+|------|-------------|
+| FR-003 | No auto-build without `default-client` |
+| FR-006 | `MissingHttpClient` at `build()` |
+| FR-007 | `cookies` on base `reqwest`, not only `xml` |
+| FR-008 | Single `build_default_http_client` |
+| FR-009 | `http_client()` works in both modes |
+| SOAP opt-out | Document: injected client needs `cookie_store(true)` |

--- a/specs/002-selectable-tls-backend/plan.md
+++ b/specs/002-selectable-tls-backend/plan.md
@@ -1,0 +1,189 @@
+# Implementation Plan: Selectable TLS backend / opt-out of default client configuration
+
+**Branch**: `002-selectable-tls-backend` | **Date**: 2026-06-01 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/002-selectable-tls-backend/spec.md` (GitHub [#37](https://github.com/noclue/vim_rs/issues/37))
+
+**Note**: Filled by `/speckit-plan`. Workflow: `.specify/templates/plan-template.md`.
+
+## Summary
+
+Upgrade **`reqwest` to 0.13** and rewire **`vim_rs` Cargo features** so consumers can disable **`default-client`** (`default-features = false`) and supply their own **`reqwest::Client`**—removing forced TLS/OpenSSL from the dependency tree. Turnkey users keep **`ClientBuilder`** auto-build and **`insecure(true)`** via **`default-client` → `reqwest/default`** (0.13 default TLS = **rustls**, documented breaking change). Consolidate duplicated **`reqwest::ClientBuilder`** logic in **`core/client.rs`** into one helper; **`reqwest/cookies`** remains on **`xml`** only; **`.cookie_store(true)`** only on SOAP auto-build path.
+
+## Technical Context
+
+**Language/Version**: Rust 2021, stable (reqwest 0.13 MSRV ≥ 1.85 per upstream; verify against project CI)  
+**Primary Dependencies**: `reqwest` 0.13, `tokio`, `miniserde`; optional `quick-xml` (`xml`)  
+**Storage**: N/A  
+**Testing**: `cargo test -p vim_rs`, `cargo test -p vim_rs --all-features`; optional `examples/tls_rustls_only` + `cargo tree` for SC-001; existing integration tests unchanged  
+**Target Platform**: Cross-platform library (Linux/macOS/Windows consumers)  
+**Project Type**: Rust library (`vim_rs`) + examples workspace  
+**Performance Goals**: No regression vs Principle III release gates (`vim_rs` build time, `examples/vtui` binary size)  
+**Constraints**: Hand-written changes only in `vim_rs/Cargo.toml`, `vim_rs/src/core/client.rs`, docs/locks; no generated file edits  
+**Scale/Scope**: ~100–200 LOC touched in `client.rs`; manifest + lockfiles + docs
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle / standard | Status | Evidence |
+|---------------------|--------|----------|
+| **I. Generated from specs** | Pass | No generated `types/` or `mo/` edits |
+| **II. Complete type-safe surface** | Pass | Public API additive except cfg-gated `insecure` when opted out |
+| **III. Build-time & binary budgets** | Pass | Feature-gated TLS; measure vtui size in release notes per gate |
+| **IV. Multi-transport parity** | Pass | JSON + SOAP paths share helper; run `--all-features` + snippets/vtui on release |
+| **V. Documented public surfaces** | Pass | CHANGELOG, README, `ClientBuilder` rustdoc, [contracts/](./contracts/) |
+| **VI. Readable source** | Pass | Single `build_default_http_client` (FR-008) |
+| **VII. Ecosystem tooling** | Pass | Lockfile sync for `mcp/` if needed |
+| **Marshalling (miniserde)** | Pass | Unchanged |
+| **Security & secrets** | Pass | `insecure` opt-in unchanged; SessionManager wire denylist unchanged |
+| **Feature flags** | Pass | Opt-in `default-client`; `xml`/`defaults` unchanged semantics |
+
+**Post-design re-check**: [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/) align with gates. **Documented exception**: turnkey TLS backend changes (native-tls → rustls) per FR-012—not a constitution violation when called out in CHANGELOG.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-selectable-tls-backend/
+├── plan.md              # This file
+├── research.md          # Phase 0
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1
+├── contracts/           # Phase 1
+├── spec.md
+└── tasks.md             # /speckit-tasks (not created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+vim_rs/
+├── Cargo.toml            # reqwest 0.13, features: default-client, xml tweak
+├── Cargo.lock
+└── src/core/client.rs    # build_default_http_client, cfg gates, MissingHttpClient
+
+examples/                 # optional: tls_rustls_only member for SC-001
+├── Cargo.toml
+└── snippets/ vtui/       # unchanged (default features)
+
+CHANGELOG.md
+README.md
+```
+
+**Structure Decision**: All implementation in **`vim_rs`** core client module; verification example optional under **`examples/`** workspace.
+
+## Complexity Tracking
+
+> No constitution violations requiring justification.
+
+| Violation | Why needed | Simpler alternative rejected because |
+|-----------|------------|-------------------------------------|
+| — | — | — |
+
+---
+
+## Phase 0: Research
+
+**Status**: Complete → [research.md](./research.md)
+
+Resolved decisions:
+
+| ID | Topic | Outcome |
+|----|-------|---------|
+| R1 | Feature layout | `default-client` → `reqwest/default`; base reqwest features without TLS |
+| R2 | Missing client | `Error::MissingHttpClient` at `build()` |
+| R3 | `insecure` | `#[cfg(feature = "default-client")]` |
+| R4 | Dedup | `build_default_http_client(insecure, cookie_store)` |
+| R5 | reqwest 0.13 | Pin 0.13; turnkey rustls via reqwest defaults |
+| R6 | SC-001 proof | Optional `examples/tls_rustls_only` |
+| R7 | Docs | CHANGELOG breaking TLS note |
+| R8 | Lockfiles | Update vim_rs + examples + mcp locks |
+
+No open **NEEDS CLARIFICATION** items.
+
+---
+
+## Phase 1: Design
+
+**Status**: Complete
+
+### Manifest (target)
+
+```toml
+[features]
+default = ["default-client"]
+defaults = []
+default-client = ["reqwest/default"]
+xml = ["dep:quick-xml", "reqwest/cookies"]
+vcsim_compat = ["xml"]
+
+[dependencies.reqwest]
+version = "0.13"
+default-features = false
+features = ["charset", "http2", "system-proxy"]
+```
+
+### `core/client.rs` changes
+
+1. Add **`build_default_http_client(insecure, cookie_store) -> Result<reqwest::Client>`** (`#[cfg(feature = "default-client")]`).
+2. Replace inline builders in **`build_json`**, **`build_soap_facade`**, **`build_auto_facade`** with helper calls.
+3. Feature-gated **`ClientBuilder::new`**:
+   - `default-client` on: `new(server: &str)`
+   - `default-client` off: `new(server: &str, http_client: reqwest::Client)` (required)
+4. Resolve client in **`build()`**: use `self.http_client` (always `Some` when opted out); when `default-client` on and `None`, call `build_default_http_client(...)`.
+5. **`#[cfg(feature = "default-client")]`** on **`insecure()`** and **`http_client()`** (override only on turnkey path).
+
+### Tests
+
+| Test | Purpose |
+|------|---------|
+| Existing wire/client tests | Regression default + `xml` |
+| New: `build_without_client_errors_when_default_client_disabled` | Use `[[test]]` + `required-features = []` cannot express “feature off”. Prefer **integration test in `examples/tls_rustls_only`** or `#[cfg(not(feature = "default-client"))]` unit test in separate **dev-only** pattern — simplest: **document + manual**; optional compile-only example that calls `build()` without client under `default-features = false` |
+| `cargo tree -i openssl-sys` | SC-001 / SC-007 verification |
+
+### Documentation deliverables
+
+- **CHANGELOG [Unreleased]**: `default-client`, opt-out instructions, **TLS default rustls**, `xml` no longer pulls `cookies`
+- **README**: feature table + consumer `Cargo.toml` snippet
+- **`ClientBuilder` rustdoc**: feature + injection + SOAP cookie note
+
+Artifacts: [data-model.md](./data-model.md), [contracts/README.md](./contracts/README.md), [quickstart.md](./quickstart.md)
+
+**Post-design constitution re-check**: Pass (see table above).
+
+---
+
+## Phase 2: Implementation tasks (preview for `/speckit-tasks`)
+
+Not created by this command. Suggested task groups:
+
+1. **Manifest & lockfiles** (Cargo.toml, locks)
+2. **Client refactor** (helper, cfg, error, dedupe)
+3. **Docs** (CHANGELOG, README, rustdoc)
+4. **Verification** (tests, optional `tls_rustls_only` example, tree checks)
+5. **Release notes** (TLS breaking change, Principle III metrics if releasing)
+
+---
+
+## Risk & mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Corporate CA trust differs rustls vs native-tls | reqwest 0.13 uses platform verifier; document in CHANGELOG; opt-out users choose backend |
+| Examples call `insecure()` | Default features unchanged; method remains |
+| MSRV bump from reqwest 0.13 | Check CI/toolchain; note in CHANGELOG if raised |
+| MCP/examples lockfile conflicts | `cargo update -p reqwest` in each workspace |
+
+## Acceptance mapping (spec → plan)
+
+| Criterion | Plan element |
+|-----------|----------------|
+| SC-001 | Opt-out + `cargo tree`; `examples/tls_rustls_only` |
+| SC-002 | Default features; snippets/vtui unchanged |
+| SC-003 | `cookies` on base reqwest |
+| SC-004 | Document cross-compile in README/quickstart |
+| SC-005 | `build_default_http_client` |
+| SC-006 | Compile-fail / cfg-gated `new(server, client)` |
+| SC-007 | `default-client` → `reqwest/default`; CHANGELOG |

--- a/specs/002-selectable-tls-backend/quickstart.md
+++ b/specs/002-selectable-tls-backend/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: Selectable TLS / opt-out default client
+
+**Feature**: [spec.md](./spec.md) | **Plan**: [plan.md](./plan.md)
+
+For implementers and consumers validating issue #37.
+
+## Prerequisites
+
+- Branch **`002-selectable-tls-backend`**
+- Read [research.md](./research.md) for manifest layout
+
+## Implementation order
+
+1. **`vim_rs/Cargo.toml`** — reqwest `0.13`, `default-features = false`, base features; add `default-client`; decouple `cookies` from `xml`.
+2. **`vim_rs/src/core/client.rs`** — `build_default_http_client`; cfg-gate auto-build + `insecure`; `MissingHttpClient`; dedupe three call sites.
+3. **`vim_rs/src/lib.rs`** — re-export / docs if needed.
+4. **Tests** — `cargo test -p vim_rs`, `cargo test -p vim_rs --all-features`; optional unit test for `MissingHttpClient` with `required-features` inverse (see below).
+5. **Docs** — `CHANGELOG.md`, `README.md`, `ClientBuilder` rustdoc.
+6. **Lockfiles** — `vim_rs/Cargo.lock`, `examples/Cargo.lock`, `mcp/Cargo.lock`.
+7. **Verification crate** (recommended) — `examples/tls_rustls_only` for SC-001.
+
+## Commands (reference)
+
+```bash
+# Default path (unchanged examples)
+RUSTUP_HOME=/Users/kiril/.rustup CARGO_HOME=/Users/kiril/.cargo \
+  /Users/kiril/.cargo/bin/cargo test -p vim_rs
+
+RUSTUP_HOME=/Users/kiril/.rustup CARGO_HOME=/Users/kiril/.cargo \
+  /Users/kiril/.cargo/bin/cargo test -p vim_rs --all-features
+
+# Confirm turnkey uses rustls, not openssl-sys
+RUSTUP_HOME=/Users/kiril/.rustup CARGO_HOME=/Users/kiril/.cargo \
+  /Users/kiril/.cargo/bin/cargo tree -p vim_rs -i openssl-sys
+
+# Opt-out consumer (from examples/tls_rustls_only or local crate)
+RUSTUP_HOME=/Users/kiril/.rustup CARGO_HOME=/Users/kiril/.cargo \
+  /Users/kiril/.cargo/bin/cargo tree -i openssl-sys
+# expect: no packages
+```
+
+## Consumer snippet (opt-out)
+
+```rust
+use std::sync::Arc;
+use vim_rs::core::client::{ClientBuilder, Error};
+
+let http = reqwest::Client::builder()
+    .build()
+    .map_err(Error::ReqwestError)?;
+
+let client = ClientBuilder::new("vcenter.example.com", http)
+    .basic_authn("user", "pass")
+    .build()
+    .await?;
+```
+
+With `xml` + SOAP, enable cookies on **your** builder:
+
+```rust
+let http = reqwest::Client::builder()
+    .cookie_store(true)
+    .build()?;
+```
+
+## Definition of done (preview)
+
+- `cargo tree -i openssl-sys` empty for opt-out verification crate.
+- Default `cargo test -p vim_rs` and `--all-features` pass.
+- `core/client.rs` has one `build_default_http_client` (SC-005).
+- CHANGELOG notes TLS default change (FR-012).
+
+Full tasks: **`/speckit-tasks`** → `tasks.md`.

--- a/specs/002-selectable-tls-backend/research.md
+++ b/specs/002-selectable-tls-backend/research.md
@@ -1,0 +1,126 @@
+# Research: Selectable TLS backend / opt-out of default client configuration
+
+**Feature**: [spec.md](./spec.md)  
+**Date**: 2026-06-01  
+**Tracks**: GitHub issue [#37](https://github.com/noclue/vim_rs/issues/37)
+
+Each item: **Decision**, **Rationale**, **Alternatives considered**.
+
+---
+
+## R1 — Feature flag layout (`vim_rs` + `reqwest`)
+
+**Decision**: Introduce a **`default-client`** feature on `vim_rs`, enabled by the crate **`default`** feature array. Wire:
+
+```toml
+[features]
+default = ["default-client"]
+default-client = ["reqwest/default"]
+
+[dependencies.reqwest]
+version = "0.13"
+default-features = false
+features = ["charset", "http2", "system-proxy", "cookies"]
+
+xml = ["dep:quick-xml", "reqwest/cookies"]   # cookies only for SOAP cookie_store
+```
+
+Consumers opt out with `vim_rs = { version = "…", default-features = false }`. They then enable TLS on **their** `reqwest` dependency (e.g. `features = ["rustls"]`) and call `ClientBuilder::http_client(injected)`.
+
+**Rationale**: Matches spec FR-001/002/011: turnkey path enables reqwest’s **default** feature set (0.13 → `default-tls` → `rustls`); opt-out removes `reqwest/default` from the unified feature graph so `openssl-sys` is not pulled unless the consumer adds `native-tls`. **`reqwest/cookies` stays on `xml` only** (FR-007): VI/JSON uses header session auth, not cookie jar; only SOAP auto-build calls `.cookie_store(true)`.
+
+**Alternatives considered**:
+
+- **`native-tls` / `rustls-tls` toggles on `vim_rs`** (issue #37 draft) — **rejected** per spec FR-011 (user: use reqwest defaults on turnkey; no per-backend vim_rs toggles).
+- **`reqwest` with `default-features = true` always** — **rejected** (cannot satisfy FR-001; Cargo features are additive from dependents).
+- **Optional `reqwest` dependency** — **rejected** (`reqwest::Client` is public API on `ClientBuilder::http_client`).
+
+---
+
+## R2 — Failure mode when opted out without injected client (FR-006)
+
+**Decision**: **Compile-time enforcement** via feature-gated `ClientBuilder::new` signatures:
+
+- **`default-client` on**: `new(server_address: &str) -> Self` (unchanged); optional `http_client()` override before `build()`.
+- **`default-client` off**: `new(server_address: &str, http_client: reqwest::Client) -> Self` — **required** client at construction; `http_client()` not in API surface.
+
+No runtime `MissingHttpClient` on `build()` for opt-out mode.
+
+**Rationale**: Spec clarification (2026-06-01): fail as early as possible; impossible to construct a builder without a client when opted out. `#[cfg(feature = "default-client")]` on `impl` methods is idiomatic Rust and avoids a second builder type.
+
+**Alternatives considered**:
+
+- **Runtime error at `build().await`** — **rejected** (user clarification; weaker than compile-time).
+- **Separate `ClientBuilderMinimal` type** — **rejected** (API duplication; cfg-gated `new` is sufficient).
+
+---
+
+## R3 — `insecure(true)` when `default-client` is off (FR-004 edge case)
+
+**Decision**: **`#[cfg(feature = "default-client")]`** on `ClientBuilder::insecure` (and keep `http_client` always available). Opt-out consumers configure TLS on their injected `reqwest::Client` (e.g. `tls_danger_accept_invalid_certs`).
+
+**Rationale**: Spec allows compile-time absence; avoids silent no-op that looks like it worked. Examples/snippets use default features and keep `insecure()`.
+
+**Alternatives considered**:
+
+- **Runtime warning + ignore** — **rejected** (ambiguous).
+- **Keep method, error at `build`** — **acceptable** but worse than cfg for discoverability.
+
+---
+
+## R4 — Shared default HTTP client helper (FR-008)
+
+**Decision**: Single private function in `core/client.rs`, e.g. `build_default_http_client(insecure: Option<bool>, cookie_store: bool) -> Result<reqwest::Client>`, called from `build_json` (`false`), `build_soap_facade` (`true`, `#[cfg(feature = "xml")]`), and `build_auto_facade` probe (`false`). `.cookie_store(true)` is compiled only when `cookie_store` is true **and** `feature = "xml"` (or the call site is already xml-gated).
+
+**Rationale**: Three copies today; SOAP needs cookies; JSON/hello probe do not. Aligns with actual transport semantics (header auth vs cookie jar).
+
+**Alternatives considered**:
+
+- **Unconditional `cookies` on base reqwest dep** — **rejected** (spec clarification 2026-06-01; bloats JSON-only builds).
+- **Always enable cookie store on all transports** — **rejected** (unnecessary for JSON).
+
+---
+
+## R5 — reqwest 0.13 upgrade details
+
+**Decision**: Pin **`reqwest = "0.13"`** (latest patch in series). Turnkey TLS = reqwest **`default`** → **`default-tls`** → **`rustls`** with **`rustls-platform-verifier`** (OS trust store). Keep using **`danger_accept_invalid_*`** on `ClientBuilder` (soft-deprecated aliases still present in 0.13.2); optional follow-up to rename to `tls_danger_accept_invalid_*`.
+
+**Rationale**: Spec FR-011/012; platform verifier preserves corporate-CA vCenter behavior vs webpki-only roots. Aliases avoid churn in this PR.
+
+**Alternatives considered**:
+
+- **Stay on 0.12 + only feature flags** — **rejected** (user plan item 1).
+- **Pin native-tls on turnkey via `reqwest/native-tls`** — **rejected** (contradicts FR-011 / user clarification).
+
+---
+
+## R6 — Verification of OpenSSL-free opt-out (SC-001)
+
+**Decision**: Add a minimal **`examples/tls_rustls_only`** workspace member (or documented one-liner consumer in `quickstart.md`) that depends on `vim_rs` with `default-features = false`, `reqwest` with `features = ["rustls", "cookies", …]`, and runs `cargo tree -i openssl-sys` expecting empty output. Wire into manual/CI checklist in `quickstart.md`; not required for default `cargo test -p vim_rs`.
+
+**Rationale**: Root repo is not a Cargo workspace with `vim_rs`; feature-matrix tests inside `vim_rs` cannot easily assert absence of transitive deps without a separate manifest.
+
+**Alternatives considered**:
+
+- **Only document manual steps** — **acceptable** but weaker SC-001 evidence.
+- **`trybuild` compile-fail** — **insufficient** for dependency-tree claims.
+
+---
+
+## R7 — Documentation / breaking-change messaging (FR-010, FR-012)
+
+**Decision**: **`CHANGELOG.md` [Unreleased]**: breaking/Changed entry — default TLS for turnkey users moves **native-tls/OpenSSL → rustls**; new `default-client` feature; how to opt out; SOAP cookie-store note when opting out. **`README.md`**: feature table + consumer manifest snippet. **`ClientBuilder` rustdoc**: feature requirements and injection examples.
+
+**Rationale**: Constitution V + spec FR-010/012; US2 “unchanged source” still holds for examples, but TLS linkage changes for default builds (documented, not hidden).
+
+**Alternatives considered**: —
+
+---
+
+## R8 — Downstream lockfiles
+
+**Decision**: Update **`vim_rs/Cargo.lock`**, **`examples/Cargo.lock`**, and **`mcp/Cargo.lock`** after `reqwest` bump (MCP server already uses reqwest 0.13 in dev-deps; unified resolution may change).
+
+**Rationale**: Reproducible CI; avoid drift.
+
+**Alternatives considered**: —

--- a/specs/002-selectable-tls-backend/spec.md
+++ b/specs/002-selectable-tls-backend/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: Selectable TLS Backend / Opt-Out of Default Client Configuration
+
+**Feature Branch**: `002-selectable-tls-backend`
+
+**Created**: 2026-06-01
+
+**Status**: Draft
+
+**Input**: User description: "Address GitHub issue #37. Plan: (1) bump reqwest to 0.13; (2) let a library user opt out of vim_rs's default configuration — which also removes the default reqwest configuration and the ability for ClientBuilder to auto-create a reqwest::Client; (3) deduplicate the reqwest::Client creation code in core/client.rs, currently duplicated across the JSON and XML paths."
+
+## Context & Problem
+
+`vim_rs` today depends on the HTTP client crate with its full default configuration. That default configuration forces a specific TLS backend into every downstream binary, and downstream crates cannot opt out (build configuration is additive — a consumer cannot turn off another crate's defaults from their own manifest). The practical consequences reported in issue #37 are:
+
+- **Supply-chain / image hardening**: the forced backend links a native crypto library that is a recurring source of security advisories; consumers targeting minimal/distroless images want it gone entirely (smaller image, smaller SBOM, fewer advisories to triage).
+- **Cross-compilation friction**: the forced native backend makes cross-compiling (e.g. to `linux/arm64`) painful because it needs a target build of the native crypto library; a pure-Rust backend cross-compiles cleanly.
+- **Duplication**: consumers already standardized on a pure-Rust backend end up linking two TLS stacks.
+
+This feature lets a consumer fully control the HTTP/TLS stack `vim_rs` links, while preserving today's turnkey experience for everyone who does not opt out.
+
+## Clarifications
+
+### Session 2026-06-01
+
+- Q: When users opt out of the default feature set, how must they supply an HTTP client? → A: **`ClientBuilder::new` requires a non-optional `reqwest::Client` at construction time** (feature-gated API: `new(server, http_client)` when `default-client` is off). Enforcement is **compile-time**, not a runtime error on `build()`.
+- Q: Should default auto-created `reqwest::Client` enable `cookie_store`, and should `reqwest/cookies` stay on the base dependency? → A: **No cookie store for VI/JSON.** Auto-build MUST call `.cookie_store(true)` only on the SOAP/XML transport path. The `reqwest` **`cookies` crate feature** MUST be gated on **`xml`** (not unconditional). VI/JSON session auth uses the **`vmware-api-session-id` header**, not HTTP cookies.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Build an OpenSSL-free / pure-Rust-TLS binary (Priority: P1)
+
+A consumer who hardens their image (or cross-compiles) turns off `vim_rs`'s default client configuration in their dependency declaration. With it off, `vim_rs` no longer pulls in any TLS/transport defaults from the HTTP client crate and no longer creates an HTTP client on the consumer's behalf. The consumer constructs their own HTTP client (with whatever TLS backend, roots, proxy, and timeouts they choose) and passes it as a **required** argument to **`ClientBuilder::new`**. The resulting binary links only the TLS stack the consumer selected.
+
+**Why this priority**: This is the core ask of issue #37 and the only path that actually removes the unwanted native crypto library from the dependency tree (runtime injection alone does not, because the default backend is still compiled and linked).
+
+**Independent Test**: In a throwaway consumer crate, depend on `vim_rs` with default features disabled, supply a pure-Rust-TLS HTTP client, build for a Linux target, and confirm the native crypto library is absent from the dependency tree and the build succeeds (including VI/JSON session **header** auth) without the optional SOAP/XML feature enabled.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer crate that disables `vim_rs`'s default client configuration and provides its own HTTP client, **When** it builds, **Then** the native crypto library (`openssl-sys`) and the native-TLS bridge do not appear anywhere in the dependency tree.
+2. **Given** the same opted-out configuration, **When** the consumer connects and authenticates over VI/JSON, **Then** session authentication works via the **`vmware-api-session-id` header** without enabling the SOAP/XML feature (no HTTP cookie jar required).
+3. **Given** the opted-out configuration, **When** the consumer cross-compiles to another Linux architecture, **Then** the build does not require a target build of the native crypto library.
+4. **Given** the opted-out configuration, **When** the consumer attempts to call `ClientBuilder::new` without supplying an HTTP client, **Then** the project **does not compile** (the opt-out `new` signature requires `reqwest::Client`).
+
+---
+
+### User Story 2 - Existing consumers keep working unchanged (Priority: P1)
+
+A consumer who does nothing (keeps default features) sees no behavioral or source-level change: the client builder still creates an HTTP client automatically, the `insecure(true)` convenience still works, and connecting/authenticating over VI/JSON and SOAP/XML behaves exactly as before.
+
+**Why this priority**: The change must not break the large majority of consumers who rely on the turnkey path; backward compatibility for the default build is non-negotiable.
+
+**Independent Test**: Build and run the existing in-repo examples (`examples/snippets`, `examples/vtui`) and the test suite with default features and confirm no source edits are required and behavior is unchanged.
+
+**Acceptance Scenarios**:
+
+1. **Given** an unchanged consumer using default features, **When** they call the builder without supplying an HTTP client, **Then** a working client is created automatically as today.
+2. **Given** an unchanged consumer, **When** they call the `insecure(true)` convenience, **Then** certificate/hostname verification is disabled exactly as before (with the same warning).
+3. **Given** an unchanged consumer, **When** TLS verification, custom CA bundles, and connections to a vCenter fronted by a private/corporate CA are exercised, **Then** they continue to work.
+
+---
+
+### User Story 3 - Single, deduplicated client-creation path (Priority: P2)
+
+A maintainer reading `core/client.rs` finds one place that builds the default HTTP client, shared by the VI/JSON, SOAP/XML, and auto-detect transport paths, instead of three near-identical copies. The shared path correctly accounts for transport-specific needs (e.g. the session-cookie store required by SOAP/XML).
+
+**Why this priority**: Reduces maintenance risk and keeps the source readable at scale; it is a refactor that supports — but is not strictly required for — the consumer-facing goals.
+
+**Independent Test**: Inspect `core/client.rs`: the default HTTP-client construction (including the insecure flag handling and cookie-store handling) exists in exactly one helper; the JSON, SOAP, and auto-detect build paths call it. The full test suite (default and all-features) still passes.
+
+**Acceptance Scenarios**:
+
+1. **Given** the JSON, SOAP, and auto-detect build paths, **When** they need a default HTTP client, **Then** they obtain it from a single shared helper rather than constructing it inline.
+2. **Given** the SOAP/XML path (`xml` feature), **When** the shared helper auto-builds a client, **Then** `.cookie_store(true)` is applied **only** for that path so SOAP session auth keeps working; the VI/JSON path does not enable a cookie store.
+
+---
+
+### Edge Cases
+
+- **Opt-out with no HTTP client at construction**: A consumer disables the default configuration but calls a `new` entry point that omits `reqwest::Client`. The project **must not compile** (see FR-006); there is no runtime fallback on `build()`.
+- **Opt-out + `insecure(true)`**: With the default configuration off, `vim_rs` does not create or configure the HTTP client, so the `insecure` convenience is not applicable. The behavior when an opted-out consumer references the insecure convenience must be unambiguous (compile-time absence or a clearly documented no-effect), not a silent partial behavior.
+- **SOAP/XML without the default config**: The session-cookie store is part of `vim_rs`'s default client creation. When a consumer opts out and uses SOAP/XML, they are responsible for enabling a cookie store on their injected client; this requirement must be documented.
+- **JSON-only builds without `xml`**: Default auto-built clients for VI/JSON MUST NOT enable `cookie_store`; the `reqwest/cookies` dependency feature MUST NOT be required for JSON-only builds. VI/JSON session state uses response/request headers, not the cookie jar.
+- **TLS default change on upgrade**: Upgrading the HTTP client crate to 0.13 changes the out-of-the-box TLS backend for the turnkey path from native-TLS (OpenSSL) to the pure-Rust stack (rustls), because `vim_rs` simply enables that crate's default feature set (FR-011). This is a deliberate, documented behavior change for existing turnkey consumers (FR-012), not an accident.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `vim_rs` MUST allow a consumer to disable, from their own dependency declaration, the bundled default client configuration — including any TLS/transport defaults `vim_rs` would otherwise force into the dependency tree via the HTTP client crate.
+- **FR-002**: When the default client configuration is disabled, `vim_rs` MUST NOT pull in the HTTP client crate's default feature set (so the consumer's selected TLS backend is the only one compiled/linked), while still depending on the HTTP client crate for the injected-client API surface.
+- **FR-003**: When the default client configuration is disabled, `vim_rs` MUST NOT auto-create an HTTP client; the consumer MUST supply one as a **required** parameter to **`ClientBuilder::new`** (feature-gated signature: `new(server_address, http_client)`). The optional `http_client()` override on the builder MUST NOT be the only injection path in opt-out mode (that method is for turnkey overrides only; see FR-009).
+- **FR-004**: When the default client configuration is enabled (the default), `vim_rs` MUST preserve today's turnkey behavior: the builder auto-creates a working HTTP client when none is injected, and the `insecure(true)` convenience disables certificate/hostname verification with the existing warning.
+- **FR-005**: The HTTP client crate dependency MUST be upgraded to its 0.13 series, and the default (turnkey) path MUST continue to support TLS verification, custom CA bundles, connections to vCenter fronted by a private/corporate CA, and the `insecure(true)` escape hatch.
+- **FR-006**: When the default client configuration is disabled, **`ClientBuilder::new` MUST require a `reqwest::Client` argument** (non-optional). Omitting it MUST be a **compile-time error** via feature-gated API surface, not a runtime error on `build()`. The system MUST NOT silently fall back to auto-creating a client at `build()`.
+- **FR-007**: VI/JSON session authentication MUST continue to work on the default (turnkey) build **without** the `xml` feature enabled, using the existing **`vmware-api-session-id` header** mechanism (not HTTP cookies). The `reqwest` **`cookies` crate feature** MUST be enabled only when the **`xml`** feature is enabled; JSON-only builds MUST NOT depend on `reqwest/cookies`.
+- **FR-008**: The default HTTP-client construction logic (including insecure-flag handling) MUST exist in a single shared helper in `core/client.rs`, used by the VI/JSON, SOAP/XML, and auto-detect build paths. The helper MUST accept a **`cookie_store: bool`** (or equivalent); **only** the SOAP/XML build path (behind `feature = "xml"`) passes `true` so `.cookie_store(true)` is applied; VI/JSON and Hello probe paths pass `false`.
+- **FR-009**: With **default client configuration enabled**, consumers MAY use `ClientBuilder::new(server_address)` and optionally override the HTTP client via `http_client()` before `build()`. With **default client configuration disabled**, consumers MUST pass `reqwest::Client` to `new(server_address, http_client)`; `http_client()` MUST NOT be available (compile-time) so injection is unambiguous at construction. Transport behavior after a client is supplied MUST be identical in both modes.
+- **FR-010**: User-visible changes — the new opt-out capability, the TLS-backend implications, the cookie capability move, and any behavior change to the default TLS backend — MUST be documented in `CHANGELOG.md`, `README.md`, and crate-level/builder rustdoc, including the requirement to bring a cookie-enabled client when using SOAP/XML in opt-out mode.
+- **FR-011**: The turnkey (default-config-enabled) path MUST enable the HTTP client crate's own default feature set rather than pinning a specific TLS backend; whatever TLS backend that crate ships as its default at the pinned version is the turnkey default. With the 0.13 upgrade this means the turnkey default TLS backend becomes the pure-Rust stack (rustls), and `vim_rs` MUST NOT force the previous native-TLS backend back on. `vim_rs` MUST NOT expose its own per-backend selection toggles; consumers who need a different backend opt out of the default configuration (FR-001–FR-003) and inject their own client.
+- **FR-012**: Because FR-011 changes the out-of-the-box TLS backend for existing turnkey consumers (native-TLS → rustls), this behavior change MUST be called out explicitly as a notable (potentially breaking) change in `CHANGELOG.md` and `README.md`, including that the turnkey path no longer links the native crypto library by default.
+
+### Non-Functional / Constraints
+
+- **NFR-001**: The change to default-feature wiring and client construction MUST NOT regress `vim_rs` debug/release build time or `examples/vtui` binary size beyond the project's release-gate tolerances; the SOAP/XML and `defaults` features remain opt-in.
+- **NFR-002**: Marshalling, error handling, async-I/O, and wire-diagnostics conventions remain unchanged; this feature only affects dependency wiring and HTTP-client construction, not transport semantics.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A consumer crate that disables `vim_rs`'s default client configuration and injects a pure-Rust-TLS HTTP client produces a dependency tree with **zero** occurrences of the native crypto library (`openssl-sys`) and the native-TLS bridge, verifiable with a dependency-tree inspection.
+- **SC-002**: The default (turnkey) build requires **no** source changes from existing consumers: in-repo examples and tests build and behave identically to the prior release on both VI/JSON and SOAP/XML.
+- **SC-003**: VI/JSON session authentication (via **`vmware-api-session-id` header**) succeeds on a default build **without** the `xml` feature enabled, with **no** `reqwest/cookies` in the dependency graph for that build configuration.
+- **SC-004**: The opted-out configuration cross-compiles to at least one additional Linux architecture **without** requiring a target build of the native crypto library.
+- **SC-005**: `core/client.rs` contains exactly **one** default-HTTP-client construction helper; the JSON, SOAP, and auto-detect paths all call it, and `cargo test` (default and all-features) passes.
+- **SC-006**: A consumer who opts out and omits `reqwest::Client` from `ClientBuilder::new` **cannot compile** — confirmable by a compile-fail test, API documentation, or review of the feature-gated `new` signature (not a runtime `build()` failure).
+- **SC-007**: On a default (turnkey) build with the 0.13 upgrade, the linked TLS backend is the HTTP client crate's default (rustls) — verifiable by dependency-tree inspection — and this change is recorded as a notable change in `CHANGELOG.md`/`README.md`.
+
+## Assumptions
+
+- The opt-out is expressed through `vim_rs`'s feature wiring: a default-on feature carries the bundled client configuration (HTTP-client-crate defaults needed by `vim_rs` plus the auto-create/`insecure` convenience), and disabling default features turns it off. Exact feature naming is an implementation/plan decision.
+- The HTTP client crate remains a non-optional dependency of `vim_rs` because its client type appears in the public injection API; opting out changes which of *its* features `vim_rs` enables, not whether it is present.
+- Opt-out enforcement uses **compile-time** API shape: `ClientBuilder::new(server, http_client)` when `default-client` is disabled; turnkey keeps `new(server)` only (FR-006).
+- The pure-Rust default of the upgraded HTTP client crate uses the platform/OS trust store, which preserves compatibility with vCenter fronted by private/corporate CAs (matching the prior native backend's behavior); webpki-only roots are not assumed.
+- `vim_rs` uses none of the HTTP client crate's `json` / `stream` / `multipart` / compression features and does not need them re-added when defaults are disabled. The **`cookies`** reqwest feature is **SOAP/XML-only** (`xml` feature); VI/JSON does not use HTTP cookie storage for sessions.
+- This repository's generated-binding policy is unaffected: changes are confined to `vim_rs/Cargo.toml` and hand-written `core/client.rs` (and docs), not generated files.
+
+## Out of Scope
+
+- Replacing the HTTP client crate with a different library, or changing transport semantics (request/response handling, wire logging, session management).
+- Adding runtime TLS configuration knobs to `vim_rs` beyond the existing injected-client entry point and `insecure` convenience.
+- Per-consumer migration tooling or forks; the change is a manifest/feature-wiring change plus a documented client-injection requirement in opt-out mode.
+- Broadening certificate/roots handling beyond what the upgraded HTTP client crate provides by default and via the consumer's injected client.

--- a/specs/002-selectable-tls-backend/tasks.md
+++ b/specs/002-selectable-tls-backend/tasks.md
@@ -1,0 +1,197 @@
+# Tasks: Selectable TLS backend / opt-out of default client configuration
+
+**Input**: Design documents from `/specs/002-selectable-tls-backend/`  
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/README.md](./contracts/README.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Not requested in spec — verification via `cargo test`, `cargo tree`, and optional `examples/tls_rustls_only` crate (SC-001/SC-006).
+
+**Organization**: Tasks grouped by user story (P1 → P2) with shared foundation first.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no blocking deps on incomplete tasks)
+- **[Story]**: US1, US2, US3 per [spec.md](./spec.md)
+
+## Path Conventions
+
+- Library crate: `vim_rs/`
+- Examples workspace: `examples/`
+- Root docs: `CHANGELOG.md`, `README.md`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Align manifest and design contracts before code changes.
+
+- [x] T001 Review API contracts in `specs/002-selectable-tls-backend/contracts/README.md` against current `vim_rs/src/core/client.rs`
+- [x] T002 Update `vim_rs/Cargo.toml`: `reqwest = "0.13"`, `default-features = false`, base features `charset`/`http2`/`system-proxy`; add `default = ["default-client"]`, `default-client = ["reqwest/default"]`; set `xml = ["dep:quick-xml", "reqwest/cookies"]` (remove duplicate cookies from base)
+- [x] T003 [P] Document target feature matrix in `specs/002-selectable-tls-backend/quickstart.md` if manifest naming differs from plan (keep quickstart in sync with final `Cargo.toml`)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: reqwest 0.13 upgrade, shared HTTP client builder, and `default-client` cfg infrastructure. **Blocks all user stories.**
+
+**⚠️ CRITICAL**: No user story validation until this phase completes.
+
+- [x] T004 Add `#[cfg(feature = "default-client")]` helper `build_default_http_client(insecure: Option<bool>, cookie_store: bool) -> Result<reqwest::Client>` in `vim_rs/src/core/client.rs` (use `tls_danger_accept_invalid_*` or existing aliases; apply `.cookie_store(true)` only when `cookie_store` is true)
+- [x] T005 Replace duplicated inline `reqwest::ClientBuilder` blocks in `build_json`, `build_soap_facade`, and `build_auto_facade` in `vim_rs/src/core/client.rs` with calls to `build_default_http_client` (`cookie_store: false` for JSON and Hello probe; `cookie_store: true` for SOAP path only)
+- [x] T006 Gate auto-created client behind `#[cfg(feature = "default-client")]` in `build_json`, `build_soap_facade`, and `build_auto_facade` in `vim_rs/src/core/client.rs` (when cfg off, use `self.http_client` from `new(server, client)` only)
+- [x] T007 Implement feature-gated `ClientBuilder::new` in `vim_rs/src/core/client.rs`: `new(server)` with `default-client`; `new(server, http_client: reqwest::Client)` without `default-client`
+- [x] T008 Add `#[cfg(feature = "default-client")]` to `ClientBuilder::insecure` and `ClientBuilder::http_client` in `vim_rs/src/core/client.rs`
+- [x] T009 Run `RUSTUP_HOME=~/.rustup CARGO_HOME=~/.cargo cargo check -p vim_rs` and `cargo check -p vim_rs --all-features`; fix reqwest 0.13 API breakages in `vim_rs/src/core/client.rs` and `vim_rs/src/xml/client.rs` if any
+- [x] T010 Update `vim_rs/Cargo.lock` after manifest and dependency resolution
+
+**Checkpoint**: `vim_rs` compiles with new features; single `build_default_http_client`; SOAP-only `cookie_store`.
+
+---
+
+## Phase 3: User Story 1 — OpenSSL-free / opt-out build (Priority: P1) 🎯 MVP
+
+**Goal**: Consumers can disable `default-client` and supply their own `reqwest::Client` at `new`, with no forced TLS/OpenSSL from `vim_rs`.
+
+**Independent Test**: `examples/tls_rustls_only` (or equivalent) builds with `vim_rs` `default-features = false`; `cargo tree -i openssl-sys` is empty; VI/JSON connects with header session auth without `xml` feature.
+
+### Implementation for User Story 1
+
+- [x] T011 [US1] Ensure `build()` paths in `vim_rs/src/core/client.rs` never call `build_default_http_client` when `default-client` is disabled (client always taken from `new(server, http_client)`)
+- [x] T012 [P] [US1] Add `examples/tls_rustls_only/` workspace member: `Cargo.toml` with `vim_rs = { default-features = false }`, `reqwest` with `rustls` + base features, minimal `main.rs` using `ClientBuilder::new(host, http)` per `specs/002-selectable-tls-backend/quickstart.md`
+- [x] T013 [P] [US1] Register `tls_rustls_only` in `examples/Cargo.toml` workspace `members`
+- [x] T014 [US1] Run `cargo tree -i openssl-sys` in `examples/tls_rustls_only/` and confirm empty output (SC-001)
+- [x] T015 [US1] Add opt-out consumer `Cargo.toml` snippet and feature table to `README.md` (FR-010)
+
+**Checkpoint**: Opt-out consumer builds without `openssl-sys`; compile-time `new(server, client)` enforced.
+
+---
+
+## Phase 4: User Story 2 — Turnkey consumers unchanged (Priority: P1)
+
+**Goal**: Default features preserve auto-build, `insecure(true)`, and unchanged examples/tests; document TLS backend change (native-tls → rustls).
+
+**Independent Test**: `cargo test -p vim_rs`, `cargo test -p vim_rs --all-features`, `examples/snippets` and `examples/vtui` build without source edits.
+
+### Implementation for User Story 2
+
+- [x] T016 [US2] Verify turnkey `build_json` auto-creates client when `http_client` unset and `default-client` enabled in `vim_rs/src/core/client.rs`
+- [x] T017 [US2] Verify `insecure(true)` still applies via `build_default_http_client` on turnkey path in `vim_rs/src/core/client.rs`
+- [x] T018 [US2] Run `cargo test -p vim_rs` from repo root (default features)
+- [x] T019 [US2] Run `cargo test -p vim_rs --all-features` from repo root
+- [x] T020 [P] [US2] Run `cargo build` in `examples/` for `snippets` and `vtui` without modifying their sources (SC-002)
+- [x] T021 [US2] Run `cargo tree -p vim_rs -i openssl-sys` on default features; confirm empty (SC-007 rustls default) and note in `CHANGELOG.md`
+
+**Checkpoint**: All default-feature tests and examples pass; TLS change documented.
+
+---
+
+## Phase 5: User Story 3 — Deduplicated client creation (Priority: P2)
+
+**Goal**: Exactly one default HTTP client construction helper; cookie store only on SOAP/XML auto-build.
+
+**Independent Test**: Code review of `vim_rs/src/core/client.rs` — one helper, three call sites; JSON/auto probe use `cookie_store: false`; SOAP uses `true`.
+
+### Implementation for User Story 3
+
+- [x] T022 [US3] Audit `vim_rs/src/core/client.rs`: confirm no remaining inline `reqwest::ClientBuilder::new()` duplication outside `build_default_http_client` (SC-005)
+- [x] T023 [US3] Audit test helpers in `vim_rs/src/core/client.rs` (`test_dead_port_http_client`, etc.): align `cookie_store` with `xml` cfg where `.cookie_store(true)` is used
+- [x] T024 [US3] Confirm `cargo tree -p vim_rs --no-default-features` shows no `cookie_store`/`cookies` dep unless `xml` enabled (SC-003)
+
+**Checkpoint**: FR-008 satisfied; JSON-only builds omit `reqwest/cookies`.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, lockfiles, release notes.
+
+- [x] T025 [P] Add `[Unreleased]` entry to `CHANGELOG.md`: `default-client` feature, opt-out instructions, TLS default rustls (FR-012), `reqwest/cookies` on `xml` only
+- [x] T026 [P] Expand `ClientBuilder` and feature-flag rustdoc in `vim_rs/src/core/client.rs` (opt-out `new`, SOAP cookie requirement, turnkey vs injected client)
+- [x] T027 [P] Update `vim_rs/src/lib.rs` crate-level docs if `ClientBuilder` usage is referenced at crate root
+- [x] T028 Update `examples/Cargo.lock` and `mcp/Cargo.lock` after reqwest 0.13 resolution
+- [x] T029 Run full validation from `specs/002-selectable-tls-backend/quickstart.md` (test commands + tree checks)
+- [x] T030 [P] Record `vim_rs` / `examples/vtui` build-time and binary-size notes in `CHANGELOG.md` if Principle III release gate is measured for this release (NFR-001)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)** → **Phase 2 (Foundational)** → **Phases 3–5 (User Stories)** → **Phase 6 (Polish)**
+- **US1** and **US2** both depend on Phase 2; can proceed in parallel after T010
+- **US3** is mostly satisfied by T004–T005; T022–T024 validate after US1/US2
+
+### User Story Dependencies
+
+| Story | Depends on | Can parallel with |
+|-------|------------|-------------------|
+| **US1** (P1) | Phase 2 complete | US2 after T010 |
+| **US2** (P1) | Phase 2 complete | US1 after T010 |
+| **US3** (P2) | T004–T005 (Phase 2) | US1/US2 validation |
+
+### Within Each User Story
+
+- Manifest (T002) before compile fixes (T009)
+- Helper + dedupe (T004–T005) before cfg-gated `new` (T007)
+- US1 verification crate (T012–T014) after opt-out `build()` wiring (T011)
+- Docs (T025–T026) after behavior stable (T018–T021)
+
+### Parallel Opportunities
+
+- **Phase 1**: T003 ∥ T002 (after T001)
+- **Phase 3**: T012 ∥ T013; T014 after both
+- **Phase 4**: T020 ∥ T021 (after tests T018–T019)
+- **Phase 6**: T025 ∥ T026 ∥ T027; T028 after T010
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After Phase 2 checkpoint:
+# Agent A: T011 (build() wiring) then T014 (tree verify)
+# Agent B: T012 + T013 (tls_rustls_only crate) in parallel
+```
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# After Phase 2 checkpoint:
+# Agent A: T016–T017 (code verify) → T018–T019 (tests)
+# Agent B: T020 (examples build) → T021 (openssl tree + CHANGELOG note)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Complete Phase 1 + Phase 2 (T001–T010)
+2. Complete Phase 3 US1 (T011–T015)
+3. **STOP and VALIDATE**: `tls_rustls_only` + empty `openssl-sys` tree
+4. Add US2 + polish before release
+
+### Incremental Delivery
+
+1. Foundation (reqwest 0.13 + helper + cfg) → compiles
+2. US1 opt-out → SC-001/SC-006
+3. US2 turnkey regression → SC-002/SC-007
+4. US3 audit → SC-005/SC-003
+5. Polish docs + lockfiles
+
+### Suggested MVP Scope
+
+**Phases 1–3 (T001–T015)** deliver issue #37 core value: OpenSSL-free opt-out builds with compile-time client injection.
+
+---
+
+## Notes
+
+- Do not hand-edit generated files under `vim_rs/src/types/` or `vim_rs/src/mo/`
+- `vim_rs` root is not a workspace; run `cargo` with `-p vim_rs` from repo root
+- Use explicit `RUSTUP_HOME` / `CARGO_HOME` in CI/agent per `.cursor/rules/rust-env.mdc`
+- Turnkey TLS changes from OpenSSL to rustls (FR-012) — document, do not pin native-tls back on

--- a/tls_rustls_only/Cargo.lock
+++ b/tls_rustls_only/Cargo.lock
@@ -12,12 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,34 +68,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,20 +92,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -148,73 +106,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "clap"
-version = "4.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -288,73 +179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,18 +206,6 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "either"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -455,12 +267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,24 +312,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi",
- "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -546,27 +336,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -788,30 +561,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itoa"
@@ -893,16 +646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,12 +680,6 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -996,15 +733,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,12 +743,6 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -1078,34 +800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,15 +830,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,132 +855,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1351,7 +916,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -1375,17 +939,11 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1402,8 +960,8 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1428,7 +986,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -1465,7 +1022,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1531,7 +1087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -1743,29 +1298,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+name = "tls_rustls_only"
+version = "0.1.0"
 dependencies = [
- "serde",
- "serde_json",
+ "reqwest",
+ "rustls",
+ "tokio",
+ "vim_rs",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1945,13 +1485,11 @@ version = "0.4.4"
 dependencies = [
  "base64",
  "bytes",
- "criterion",
  "env_logger",
  "indexmap",
  "log",
  "miniserde",
  "phf 0.13.1",
- "quick-xml",
  "reqwest",
  "rustc_version",
  "thiserror",
@@ -1983,15 +1521,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2059,16 +1588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2127,16 +1646,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2154,31 +1664,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -2188,22 +1681,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2212,22 +1693,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2236,22 +1705,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2260,28 +1717,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -2310,26 +1749,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.50"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/tls_rustls_only/Cargo.toml
+++ b/tls_rustls_only/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tls_rustls_only"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+vim_rs = { path = "../vim_rs", default-features = false }
+reqwest = { version = "0.13", default-features = false, features = [
+    "rustls-no-provider",
+    "charset",
+    "http2",
+    "system-proxy",
+    "cookies"
+] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+
+tokio = { version = "1", features = ["rt"] }

--- a/tls_rustls_only/src/main.rs
+++ b/tls_rustls_only/src/main.rs
@@ -1,0 +1,11 @@
+//! Compile-time check: `vim_rs` without `default-client` links only the consumer's TLS stack.
+//!
+//! Run `cargo tree -i openssl-sys` in this directory; expect no matches.
+
+fn main() {
+    let http = reqwest::Client::builder()
+        .cookie_store(true)  // IMPORTANT!!! SOAP/XML servers use cookies for session auth
+        .build()
+        .expect("reqwest client");
+    let _builder = vim_rs::core::client::ClientBuilder::new("vcenter.example.com", http);
+}

--- a/vim_rs/Cargo.toml
+++ b/vim_rs/Cargo.toml
@@ -14,7 +14,9 @@ categories = ["api-bindings", "network-programming"]
 exclude = ["target/*", "**/*.rs.bk"]
 
 [features]
+default = ["default-client"]
 defaults = []
+default-client = ["reqwest/default"]
 xml = ["dep:quick-xml", "reqwest/cookies"]
 # Compatibility layer for producers that emit malformed SOAP payloads
 # (notably `govc vcsim`, which omits required fields such as
@@ -36,7 +38,7 @@ indexmap = "2.9"
 log = "0.4"
 miniserde = "0.1"
 quick-xml = { version = "0.39", optional = true }
-reqwest = { version = "0.12" }
+reqwest = { version = "0.13", default-features = false }
 thiserror = "2.0"
 tokio = { version = "1.44", features = ["rt-multi-thread", "macros", "sync"] }
 vim_macros = { version = "0.4.4", path = "../vim_macros" }

--- a/vim_rs/src/core/client.rs
+++ b/vim_rs/src/core/client.rs
@@ -347,6 +347,7 @@ pub struct ClientBuilder {
     compatible_api_releases: Option<Vec<String>>,
     api_release: Option<String>,
     http_client: Option<reqwest::Client>,
+    #[cfg(feature = "default-client")]
     insecure: Option<bool>,
     app_name: Option<String>,
     app_version: Option<String>,
@@ -357,16 +358,54 @@ pub struct ClientBuilder {
     wire_logging: WireLoggingMode,
 }
 
+/// Build a `reqwest::Client` when the `default-client` feature is enabled (turnkey path).
+#[cfg(feature = "default-client")]
+fn build_default_http_client(
+    insecure: Option<bool>,
+    _cookie_store: bool,
+) -> Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder();
+    #[cfg(feature = "xml")]
+    if _cookie_store {
+        builder = builder.cookie_store(true);
+    }
+    if let Some(insecure) = insecure {
+        builder = builder
+            .danger_accept_invalid_certs(insecure)
+            .danger_accept_invalid_hostnames(insecure);
+    }
+    Ok(builder.build()?)
+}
+
+#[cfg(feature = "default-client")]
+fn obtain_http_client(
+    existing: Option<reqwest::Client>,
+    insecure: Option<bool>,
+    cookie_store: bool,
+) -> Result<reqwest::Client> {
+    match existing {
+        Some(client) => Ok(client),
+        None => build_default_http_client(insecure, cookie_store),
+    }
+}
+
+#[cfg(not(feature = "default-client"))]
+fn obtain_http_client(existing: Option<reqwest::Client>) -> Result<reqwest::Client> {
+    existing.ok_or_else(|| {
+        Error::ParseError(
+            "ClientBuilder requires a reqwest::Client from new(server, http_client)".into(),
+        )
+    })
+}
+
 impl ClientBuilder {
-    /// Create a new client builder for a VI/JSON API at given FQDN or IP address
-    ///
-    /// * `server_address` - vCenter server FQDN or IP address
-    pub fn new(server_address: &str) -> Self {
+    fn new_common(server_address: &str, http_client: Option<reqwest::Client>) -> Self {
         Self {
             server_address: server_address.to_string(),
             compatible_api_releases: None,
             api_release: None,
-            http_client: None,
+            http_client,
+            #[cfg(feature = "default-client")]
             insecure: None,
             app_name: None,
             app_version: None,
@@ -377,6 +416,51 @@ impl ClientBuilder {
             wire_logging: WireLoggingMode::default(),
         }
     }
+}
+
+#[cfg(feature = "default-client")]
+impl ClientBuilder {
+    /// Create a client builder for a VI/JSON (or SOAP with `xml`) API at the given FQDN or IP.
+    ///
+    /// When the `default-client` feature is enabled (default), a `reqwest::Client` is created
+    /// automatically at [`Self::build`] unless one is supplied via [`Self::http_client`].
+    pub fn new(server_address: &str) -> Self {
+        Self::new_common(server_address, None)
+    }
+
+    /// Set the reqwest::Client instance to use for HTTP requests.
+    ///
+    /// Resets the [`Self::insecure`] flag; configure TLS on the supplied client instead.
+    pub fn http_client(mut self, http_client: reqwest::Client) -> Self {
+        self.http_client = Some(http_client);
+        self.insecure = None;
+        self
+    }
+
+    /// Allow invalid TLS certificates and hostnames on an auto-created client.
+    ///
+    /// Resets a previously set [`Self::http_client`]; a new client is built at [`Self::build`].
+    pub fn insecure(mut self, insecure: bool) -> Self {
+        warn!("!!! WARNING !!! Insecure mode enabled. TLS certificate and hostname verification is disabled. !!! WARNING !!!");
+        self.insecure = Some(insecure);
+        self.http_client = None;
+        self
+    }
+}
+
+#[cfg(not(feature = "default-client"))]
+impl ClientBuilder {
+    /// Create a client builder with a caller-supplied `reqwest::Client`.
+    ///
+    /// Requires `default-features = false` on the `vim_rs` dependency (disables `default-client`).
+    /// Configure TLS, proxies, and (for SOAP) [`reqwest::ClientBuilder::cookie_store`] on your
+    /// client before passing it here.
+    pub fn new(server_address: &str, http_client: reqwest::Client) -> Self {
+        Self::new_common(server_address, Some(http_client))
+    }
+}
+
+impl ClientBuilder {
 
     /// Opt-in transport logging on dedicated log targets (`vim_rs::wire::json`, `vim_rs::wire::soap`).
     ///
@@ -411,26 +495,6 @@ impl ClientBuilder {
     /// * `api_release` - API release version
     pub fn api_release(mut self, api_release: &str) -> Self {
         self.api_release = Some(api_release.to_string());
-        self
-    }
-
-    /// Set the reqwest::Client instance to use for HTTP requests.
-    /// This resets the insecure flag. Use the http_client methods to set the certificate and
-    /// hostname verification behavior.
-    /// * `http_client` - preconfigured reqwest::Client instance
-    pub fn http_client(mut self, http_client: reqwest::Client) -> Self {
-        self.http_client = Some(http_client);
-        self.insecure = None;
-        self
-    }
-
-    /// Set the insecure flag to allow invalid certificates and hostnames.
-    /// This resets the http_client. A new reqwest::Client instance will be created instead.
-    /// * `insecure` - Allow invalid certificates and hostnames
-    pub fn insecure(mut self, insecure: bool) -> Self {
-        warn!("!!! WARNING !!! Insecure mode enabled. TLS certificate and hostname verification is disabled. !!! WARNING !!!");
-        self.insecure = Some(insecure);
-        self.http_client = None;
         self
     }
 
@@ -484,17 +548,10 @@ impl ClientBuilder {
 
     async fn build_json(self) -> Result<Arc<Client>> {
         let wire_logging = self.wire_logging;
-        let http_client = match self.http_client {
-            Some(client) => client,
-            None => {
-                let mut builder = reqwest::ClientBuilder::new();
-                if let Some(insecure) = self.insecure {
-                    builder = builder.danger_accept_invalid_certs(insecure)
-                                     .danger_accept_invalid_hostnames(insecure);
-                }
-                builder.build()?
-            },
-        };
+        #[cfg(feature = "default-client")]
+        let http_client = obtain_http_client(self.http_client, self.insecure, false)?;
+        #[cfg(not(feature = "default-client"))]
+        let http_client = obtain_http_client(self.http_client)?;
         let session_key = Arc::new(RwLock::new(None));
 
         let user_agent = user_agent(self.app_name.as_deref(), self.app_version.as_deref());
@@ -612,18 +669,10 @@ impl ClientBuilder {
 
     #[cfg(feature = "xml")]
     async fn build_soap_facade(self) -> Result<Arc<Client>> {
-        let http_client = match self.http_client {
-            Some(client) => client,
-            None => {
-                let mut builder = reqwest::ClientBuilder::new()
-                    .cookie_store(true);
-                if let Some(insecure) = self.insecure {
-                    builder = builder.danger_accept_invalid_certs(insecure)
-                                     .danger_accept_invalid_hostnames(insecure);
-                }
-                builder.build()?
-            },
-        };
+        #[cfg(feature = "default-client")]
+        let http_client = obtain_http_client(self.http_client, self.insecure, true)?;
+        #[cfg(not(feature = "default-client"))]
+        let http_client = obtain_http_client(self.http_client)?;
         let ua = user_agent(self.app_name.as_deref(), self.app_version.as_deref());
         let api_release = match self.api_release {
             Some(release) => release.clone(),
@@ -653,14 +702,11 @@ impl ClientBuilder {
     async fn build_auto_facade(self) -> Result<Arc<Client>> {
         let wl = self.wire_logging;
         let ua = user_agent(self.app_name.as_deref(), self.app_version.as_deref());
-        let http_client_for_probe = {
-            let mut builder = reqwest::ClientBuilder::new();
-            if let Some(insecure) = self.insecure {
-                builder = builder.danger_accept_invalid_certs(insecure)
-                                 .danger_accept_invalid_hostnames(insecure);
-            }
-            builder.build()?
-        };
+        #[cfg(feature = "default-client")]
+        let http_client_for_probe =
+            obtain_http_client(self.http_client.clone(), self.insecure, false)?;
+        #[cfg(not(feature = "default-client"))]
+        let http_client_for_probe = obtain_http_client(self.http_client.clone())?;
 
         let releases = self.compatible_api_releases.clone()
             .unwrap_or_else(|| COMPATIBLE_API_RELEASES.iter().map(|s| s.to_string()).collect());
@@ -1833,6 +1879,18 @@ mod wire_logging_transport_tests {
         }
     }
 
+    fn client_builder_for_wire_dead_addr() -> ClientBuilder {
+        let http = test_dead_port_http_client();
+        #[cfg(feature = "default-client")]
+        {
+            ClientBuilder::new(TEST_WIRE_DEAD_ADDR).http_client(http)
+        }
+        #[cfg(not(feature = "default-client"))]
+        {
+            ClientBuilder::new(TEST_WIRE_DEAD_ADDR, http)
+        }
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn json_hello_negotiate_and_invoke_paths_log_transport_failure() {
         let _serial = SERIAL.lock().expect("serial");
@@ -1840,8 +1898,7 @@ mod wire_logging_transport_tests {
         clear_wire_lines();
 
         // Hello System negotiation (no fixed api_release → must POST hello).
-        let hello_err = ClientBuilder::new(TEST_WIRE_DEAD_ADDR)
-            .http_client(test_dead_port_http_client())
+        let hello_err = client_builder_for_wire_dead_addr()
             .wire_logging(WireLoggingMode::Summary)
             .build()
             .await;
@@ -1954,8 +2011,7 @@ mod wire_logging_transport_tests {
         init_wire_capture();
         clear_wire_lines();
 
-        let err = ClientBuilder::new(TEST_WIRE_DEAD_ADDR)
-            .http_client(test_dead_port_http_client())
+        let err = client_builder_for_wire_dead_addr()
             .wire_logging(WireLoggingMode::Summary)
             .transport(super::TransportMode::Auto)
             .build()

--- a/vim_rs/src/lib.rs
+++ b/vim_rs/src/lib.rs
@@ -1,7 +1,8 @@
 //! # VMware vSphere API Client for Rust
 //!
-//! This crate provides a Rust interface to the VMware vSphere Virtual Infrastructure JSON API,
-//! allowing you to manage VMware infrastructure programmatically.
+//! This crate provides a Rust interface to the VMware vSphere Virtual
+//! Infrastructure JSON API, allowing you to manage VMware infrastructure
+//! programmatically.
 //!
 //! ## Connecting to vCenter
 //! To set up a connection, use a statement like the following:
@@ -24,34 +25,55 @@
 //!     Ok(())
 //! }
 //! ```
-//! `.app_details` describes your application as to be able to identify and troubleshoot sessions from the vCenter UI or SessionManager API.
+//! `.app_details` describes your application as to be able to identify and
+//! troubleshoot sessions from the vCenter UI or SessionManager API.
 //! 
-//! You can add `insecure()` to your builder configuration to bypass TLS checks for both hostname and certificate.
+//! You can add `insecure()` to your builder configuration to bypass TLS checks
+//! for both hostname and certificate.
 //! 
-//! One can set the `reqwest` preconfigured client through the builder's `http_client` method to reuse the `reqwest` connection and connection settings. The `vim_rs` client abstraction is cheap, but the `reqwest` HTTP client is not.
+//! One can set the `reqwest` preconfigured client through the builder's
+//! `http_client` method to reuse the `reqwest` connection and connection 
+//! settings. The `vim_rs` client abstraction is cheap, but the `reqwest`
+//! HTTP client is not.
+//!
+//! With default features, `vim_rs` enables **`default-client`**, which 
+//! auto-builds a `reqwest` client (TLS via **rustls** on reqwest 0.13). To
+//! supply your own TLS stack, use `default-features = false` and 
+//! `ClientBuilder::new(server, http_client)` — see the crate README and
+//! `examples/tls_rustls_only`.
 //! 
-//! The `client` above is an `Arc` around the actual client object. Use `.clone()` to pass it around.
+//! The `client` above is an `Arc` around the actual client object. Use 
+//! `.clone()` to pass it around.
 //! 
-//! If the above goes well, you have a connection to the vCenter server with an initialized session and retrieved service content.
+//! If the above goes well, you have a connection to the vCenter server with an
+//! initialized session and retrieved service content.
 //! 
 //! ## Obtaining Stub for the APIs
-//! The VIM API is a remote object-oriented API. The functionality is organized in methods of managed objects.
+//! The VIM API is a remote object-oriented API. The functionality is organized
+//! in methods of managed objects.
 //! 
-//! To set up a remote stub to a management object, one needs a connection, an object type, and an object identifier.
+//! To set up a remote stub to a management object, one needs a connection, an
+//! object type, and an object identifier.
 //! 
-//! For example, to get a handle to stub for the default `PropertyCollector`, the following code does the trick:
+//! For example, to get a handle to stub for the default `PropertyCollector`,
+//! the following code does the trick:
 //! 
 //! ```rust
 //! let content = client.service_content();
 //! let property_collector = PropertyCollector::new(client.clone(), &content.property_collector.value);
 //! ```
 //! 
-//! The `service_content` is a structure that contains references to the root managed objects in the vCenter server. Note that the `PropertyCollector` is always present in the service content. Other objects may be optional, and a check is to be made if the reference is set.
+//! The `service_content` is a structure that contains references to the root
+//! managed objects in the vCenter server. Note that the `PropertyCollector` is
+//! always present in the service content. Other objects may be optional, and a
+//! check is to be made if the reference is set.
 //! 
 //! ## Invoking APIs
-//! This is simple and intuitive once you have a remote stub from the above step.
+//! This is simple and intuitive once you have a remote stub from the above
+//! step.
 //! 
-//! The VIM API has properties and methods. Both are exposed in the stubs. Properties are essentially remote methods that receive no parameters.
+//! The VIM API has properties and methods. Both are exposed in the stubs.
+//! Properties are essentially remote methods that receive no parameters.
 //! 
 //! ```rust
 //! //! Invoke a method
@@ -61,12 +83,29 @@
 //! let vms = view.view().await?;
 //! ```
 //! 
-//! In the examples above, `collector` is an instance of `PropertyCollector`, and `view` is an instance of a `View` like `ContainerView`.
+//! In the examples above, `collector` is an instance of `PropertyCollector`,
+//! and `view` is an instance of a `View` like `ContainerView`.
 //! 
 //! ## Working with Polymorphic Types
-//! The VIM API is conceptualized as a classic object-oriented API, much like the Java or C++ standard libraries. It has a root `Any` object from which all other objects descend. There is `DataObject` that is the root for all data structures. There is also `MethodFault` that is the root for all error types.
+//! The VIM API is conceptualized as a classic object-oriented API, much like
+//! the Java or C++ standard libraries. It has a root `Any` object from which
+//! all other objects descend. There is `DataObject` that is the root for all
+//! data structures. There is also `MethodFault` that is the root for all
+//! error types.
 //! 
-//! This object-oriented design is not native to Rust. There are two principal approaches in Rust to dealing with such situations - traits and enums. Enums are easy to deal with in Rust and are extremely powerful and very safe. Unfortunately, expressing the VIM API solely in enums produces very hard-to-use abstractions of many deeply nested enum definitions that are hard to work with. Traits solve some of the usability challenges while dramatically increasing the work for the Rust compiler, which is not famous for fast performance. So the `vim_rs` library takes a hybrid approach. The often deep and complex hierarchy of the `DataObject` and `MethodFault` are represented with traits. The shallow and big inventory of boxed arrays and primitive data types used with the property collector and other dynamic APIs leverage enums with the synthetic `ValueElements` types. The VIM `Any` type is renamed to `VimAny` and is also represented as an `enum`.
+//! This object-oriented design is not native to Rust. There are two principal
+//! approaches in Rust to dealing with such situations - traits and enums.
+//! Enums are easy to deal with in Rust and are extremely powerful and very
+//! safe. Unfortunately, expressing the VIM API solely in enums produces very
+//! hard-to-use abstractions of many deeply nested enum definitions that are
+//! hard to work with. Traits solve some of the usability challenges while
+//! dramatically increasing the work for the Rust compiler, which is not famous
+//! for fast performance. So the `vim_rs` library takes a hybrid approach. The
+//! often deep and complex hierarchy of the `DataObject` and `MethodFault` are
+//! represented with traits. The shallow and big inventory of boxed arrays and
+//! primitive data types used with the property collector and other dynamic
+//! APIs leverage enums with the synthetic `ValueElements` types. The VIM `Any`
+//! type is renamed to `VimAny` and is also represented as an `enum`.
 //! 
 //! Working with the trait system is a bit more complex.
 //! 
@@ -74,7 +113,9 @@
 //! 
 //! ### Data Structs
 //! 
-//! Firstly, for every structure type from the VIM API, we have a corresponding Rust struct type. For example, a network card could be described with the `VirtualE1000` structure. It looks roughly as follows:
+//! Firstly, for every structure type from the VIM API, we have a corresponding
+//! Rust struct type. For example, a network card could be described with the
+//! `VirtualE1000` structure. It looks roughly as follows:
 //! 
 //! ```rust
 //! pub struct VirtualE1000 {
@@ -97,25 +138,48 @@
 //! }
 //! ```
 //! 
-//! Let's look at some details. First, we see that fields optional to the API use Rust `Option` (e.g., `Option<i32>`) while required fields require a valid value (e.g., `i32`). Next, we see that arrays of elements are expressed as Rust `Vec`. For fields that have children or can form a cycle, `Box` indirection is used. For fields of polymorphic types, i.e., those that have children, a `dyn *Trait` type is used, which refers to a trait type implemented by all alternative structures (`Option<Box<dyn DescriptionTrait>>`).
+//! Let's look at some details. First, we see that fields optional to the API
+//! use Rust `Option` (e.g., `Option<i32>`) while required fields require a
+//! valid value (e.g., `i32`). Next, we see that arrays of elements are
+//! expressed as Rust `Vec`. For fields that have children or can form a cycle,
+//! `Box` indirection is used. For fields of polymorphic types, i.e., those
+//! that have children, a `dyn *Trait` type is used, which refers to a trait
+//! type implemented by all alternative structures
+//! (`Option<Box<dyn DescriptionTrait>>`).
 //! 
-//! Structure types support `miniserde` JSON serialization and deserialization as well as debug print.
+//! Structure types support `miniserde` JSON serialization and deserialization
+//! as well as debug print.
 //! 
 //! ### Traits
 //! 
-//! Traits are generated for VIM structure types that have children types. The traits for a given type are implemented by all of its descendants. This allows the API to take in and return all possible types in a given field, i.e., casting an object to a trait its type implements is trivial in Rust.
+//! Traits are generated for VIM structure types that have children types. The
+//! traits for a given type are implemented by all of its descendants. This
+//! allows the API to take in and return all possible types in a given field,
+//! i.e., casting an object to a trait its type implements is trivial in Rust.
 //! 
-//! In the Rust language unlike Java, Go, and C++ there is no straightforward mechanism to upcast or downcast trait objects into other trait objects or concrete structure types. To make these possible, the `vim_rs` crate provides utilities.
+//! In the Rust language unlike Java, Go, and C++ there is no straightforward
+//! mechanism to upcast or downcast trait objects into other trait objects or concrete structure types. To make these possible, the `vim_rs` crate provides utilities.
 //! 
-//! For casting to concrete structure types, all traits in the VIM API have `AsAny` trait bound. `AsAny` allows conversion of a reference or `Box` to a reference to `&dyn Any` or `&Box<dyn Any>`. Further, a developer can use `Any` or `Box` methods to attempt fallible conversion to the target type. For example, converting a `VirtualDeviceTrait` reference to a `VirtualE1000` structure is done as follows (unwrap should be replaced with appropriate handling):
+//! For casting to concrete structure types, all traits in the VIM API have
+//! `AsAny` trait bound. `AsAny` allows conversion of a reference or `Box` to a
+//! reference to `&dyn Any` or `&Box<dyn Any>`. Further, a developer can use
+//! `Any` or `Box` methods to attempt fallible conversion to the target type.
+//! For example, converting a `VirtualDeviceTrait` reference to a
+//! `VirtualE1000` structure is done as follows (unwrap should be replaced with
+//! appropriate handling):
 //! 
 //! ```rust
 //! let e1000 = vd[0].as_any_ref().downcast_ref::<VirtualE1000>().unwrap();
 //! ```
 //! 
-//! Sometimes we want to convert from one trait to another. For example, if we want to read the MAC address of any network card device in a VM, we need to convert `VirtualDeviceTrait` into `VirtualEthernetCardTrait`. There are 2 options provided with the `CastInto` trait. One option is to convert to `Box`, and the other is to convert a borrowed reference.
+//! Sometimes we want to convert from one trait to another. For example, if we
+//! want to read the MAC address of any network card device in a VM, we need to
+//! convert `VirtualDeviceTrait` into `VirtualEthernetCardTrait`. There are 2
+//! options provided with the `CastInto` trait. One option is to convert to
+//! `Box`, and the other is to convert a borrowed reference.
 //! 
-//! In the examples below, we see how to convert `Box<dyn VirtualDevice>` into a reference and `Box` respectively:
+//! In the examples below, we see how to convert `Box<dyn VirtualDevice>` into
+//! a reference and `Box` respectively:
 //! 
 //! ```rust
 //! let eth: &dyn VirtualEthernetCardTrait = vd.as_ref().into_ref().unwrap();
@@ -123,9 +187,12 @@
 //! let eth: Box<dyn VirtualEthernetCardTrait> = vd.into_box().unwrap();
 //! ```
 //! 
-//! As Rust `TryInto` mirrors the `TryFrom` trait, `CastInto` has a mirror `CastFrom` trait.
+//! As Rust `TryInto` mirrors the `TryFrom` trait, `CastInto` has a mirror
+//! `CastFrom` trait.
 //! 
-//! Last but not least, the VIM trait provides read-only accessors to the fields of the type they represent. For example, the `VirtualDeviceTrait` looks as follows:
+//! Last but not least, the VIM trait provides read-only accessors to the
+//! fields of the type they represent. For example, the `VirtualDeviceTrait`
+//! looks as follows:
 //! 
 //! ```rust
 //! pub trait VirtualDeviceTrait : super::traits::DataObjectTrait {
@@ -141,24 +208,39 @@
 //! }
 //! ```
 //! 
-//! As we see, the same types are used as in the struct types. The `get_*` methods return borrowed references to complex types.
+//! As we see, the same types are used as in the struct types. The `get_*`
+//! methods return borrowed references to complex types.
 //! 
-//! For more details on design decisions and performance considerations, please see the FAQ section below.
+//! For more details on design decisions and performance considerations, please
+//! see the FAQ section below.
 //! 
 //! ### Pruned Types
 //! 
-//! As discussed, the VIM API is big and has a deep inheritance hierarchy. To limit the size of the library, a number of optimizations and compromises are made. One specific optimization has a direct impact on the programming model. The descendant data types of `MethodFault` and `Event` types are not generated (See [PRUNED_TYPES](vim_build/src/main.rs)). This reduces the generated code and compilation times significantly at the cost of some utility.
+//! As discussed, the VIM API is big and has a deep inheritance hierarchy. To
+//! limit the size of the library, a number of optimizations and compromises
+//! are made. One specific optimization has a direct impact on the programming
+//! model. The descendant data types of `MethodFault` and `Event` types are not
+//! generated (See [PRUNED_TYPES](vim_build/src/main.rs)). This reduces the
+//! generated code and compilation times significantly at the cost of some
+//! utility.
 //! 
-//! The `MethodFault` type represents errors that can occur when invoking VIM API methods, and the `Event` type represents events that occur in the vCenter server.
+//! The `MethodFault` type represents errors that can occur when invoking VIM
+//! API methods, and the `Event` type represents events that occur in the
+//! vCenter server.
 //! 
-//! The `MethodFault` and `Event` types do not have traits, and no descendant types are generated. Instead, both types receive 2 additional members:
+//! The `MethodFault` and `Event` types do not have traits, and no descendant
+//! types are generated. Instead, both types receive 2 additional members:
 //! 
-//! * `type_: Option<StructType>` - holding the discriminator value, e.g., `EventEx`, `NotFound`, etc.
-//! * `extra_fields_: HashMap<String, miniserde::json::Value>` - holding any data fields that are not present in the base type, e.g., `eventTypeId`.
+//! * `type_: Option<StructType>` - holding the discriminator value, e.g.,
+//! `EventEx`, `NotFound`, etc.
+//! * `extra_fields_: HashMap<String, miniserde::json::Value>` - holding any
+//! data fields that are not present in the base type, e.g., `eventTypeId`.
 //! 
-//! Note that `extra_fields_` content uses the API native names in camelCase convention instead of the Rust-friendly names used throughout `vim_rs`.
+//! Note that `extra_fields_` content uses the API native names in camelCase
+//! convention instead of the Rust-friendly names used throughout `vim_rs`.
 //! 
-//! Below is a snippet on how to decode the semantic event type using `type_name_` and `extra_fields_`:
+//! Below is a snippet on how to decode the semantic event type using
+//! `type_name_` and `extra_fields_`:
 //! 
 //! ```rust
 //! fn get_event_type_id(event: &Event) -> String {
@@ -175,11 +257,15 @@
 //! }
 //! ```
 //! 
-//! Note that `StructType` implements the `child_of` method, allowing to check if a type is the same or a descendant of another.
+//! Note that `StructType` implements the `child_of` method, allowing to check
+//! if a type is the same or a descendant of another.
 //! 
-//! In our example above, we check if the event is `EventEx` or `ExtendedEvent` to access the `eventTypeId` field.
+//! In our example above, we check if the event is `EventEx` or `ExtendedEvent`
+//! to access the `eventTypeId` field.
 //! 
-//! Sometimes one will want to convert part of the dynamic-like objects into proper binding. For example, the `managedObject` in the `ExtendedEvent` can be read into `ManagedObjectReference` as follows:
+//! Sometimes one will want to convert part of the dynamic-like objects into
+//! proper binding. For example, the `managedObject` in the `ExtendedEvent` can
+//! be read into `ManagedObjectReference` as follows:
 //! 
 //! ```rust
 //! use vim_rs::types::mini_helpers::from_value;
@@ -189,11 +275,13 @@
 //!
 //! ## Property Retrieval with Macros
 //!
-//! The library provides two powerful macros to simplify property retrieval and monitoring:
+//! The library provides two powerful macros to simplify property retrieval and
+//! monitoring:
 //!
 //! ### One-time Property Retrieval with `vim_retrievable`
 //!
-//! The `vim_retrievable` macro creates structs for efficient, one-time property retrieval:
+//! The `vim_retrievable` macro creates structs for efficient, one-time
+//! property retrieval:
 //!
 //! ```rust
 //! use vim_macros::vim_retrievable;
@@ -295,17 +383,23 @@
 //!
 //! Both macros:
 //!
-//! 1. Generate a struct based on the data structure defined in the macro, corresponding to a vSphere managed object type (VirtualMachine, HostSystem, etc.)
-//! 2. Elicit the types of struct fields from the property paths in the vSphere API
+//! 1. Generate a struct based on the data structure defined in the macro,
+//! corresponding to a vSphere managed object type (VirtualMachine, HostSystem,
+//! etc.)
+//! 2. Elicit the types of struct fields from the property paths in the vSphere
+//! API
 //! 3. Handle type conversion between vSphere types and Rust types
 //!
-//! The `vim_rs::core::pc_retrieve` module supports one-time property retrieval,
-//! while `vim_rs::core::pc_cache` provides infrastructure for continuous property monitoring.
+//! The `vim_rs::core::pc_retrieve` module supports one-time property
+//! retrieval, while `vim_rs::core::pc_cache` provides infrastructure for
+//! continuous property monitoring.
 //!
-//! These macros significantly reduce boilerplate code when working with vSphere properties
-//! and provide type-safe access to vSphere inventory objects.
+//! These macros significantly reduce boilerplate code when working with
+//! vSphere properties and provide type-safe access to vSphere inventory
+//! objects.
 //!
-// Allow proc-macros that generate `vim_rs::...` paths to work within this crate as well.
+// Allow proc-macros that generate `vim_rs::...` paths to work within this
+// crate as well.
 // (Without this, `vim_rs::` resolves only as an external crate path.)
 extern crate self as vim_rs;
 


### PR DESCRIPTION
Let consumers opt out of vim_rs's turnkey HTTP client by disabling default-features and passing a reqwest::Client to ClientBuilder::new. Turnkey builds keep auto-create, insecure(), and http_client() behind the default-client feature, which enables reqwest/default (rustls on 0.13 instead of OpenSSL).

- Bump reqwest to 0.13 with default-features = false on the dependency
- Add default-client feature (on by default); gate cookies on xml only
- Deduplicate HTTP client construction in core/client.rs
- Add tls_rustls_only example and Spec Kit docs under specs/002-*
- Document opt-out, JSON vs SOAP cookies, and cargo tree -i openssl-sys in README and CHANGELOG; refresh vim_rs/examples/mcp lockfiles

Closes #37 